### PR TITLE
Add support for running in "client" mode, and minor fixes

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -1,3 +1,7 @@
 PORT=3000
 SECRET_SERVER_ID=""
 SECRET_CLIENT_ID=""
+# Either "server" or "client".
+# The "scrape" event functionality is enabled when it's running in server mode.
+CLAWS_ENV="server"
+VERBOSE_LOGGING='true' # Enable verbose logging on the console.

--- a/index.js
+++ b/index.js
@@ -1,0 +1,4 @@
+export const providers = require('./src/scrapers/providers');
+export const resolve = require('./src/scrapers/resolvers/resolve');
+export const resolveHtml = require('./src/scrapers/resolvers/resolveHtml');
+export default require('./server');

--- a/package-lock.json
+++ b/package-lock.json
@@ -1145,6 +1145,11 @@
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
     },
+    "ejs": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/ejs/-/ejs-2.6.1.tgz",
+      "integrity": "sha512-0xy4A/twfrRCnkhfk8ErDi5DqdAsAqeGxht4xkCUrsvhhbQNs7E+4jV0CN7+NKIY0aHE72+XvqtBIXzD31ZbXQ=="
+    },
     "emitter-listener": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/emitter-listener/-/emitter-listener-1.1.2.tgz",
@@ -1692,14 +1697,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -1714,20 +1717,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -1844,8 +1844,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -1857,7 +1856,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -1872,7 +1870,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -1880,14 +1877,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -1906,7 +1901,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -1987,8 +1981,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2000,7 +1993,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2122,7 +2114,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "compression": "^1.7.3",
     "crypto-js": "^3.1.9-1",
     "dotenv": "^6.0.0",
+    "ejs": "^2.6.1",
     "express": "^4.16.3",
     "express-sse": "^0.5.0",
     "jsonwebtoken": "^8.3.0",

--- a/public/index.html
+++ b/public/index.html
@@ -185,7 +185,8 @@
         <div id="results"></div>
         <script type="text/javascript" charset="utf-8" src="bcrypt.js"></script>
         <script type="text/javascript" charset="utf-8">
-            const SECRET_CLIENT_ID = 'thisisjustaclienttest';
+            // Provided by the .env file.
+            const SECRET_CLIENT_ID = '<%= secret_client_id %>';
             const bcrypt = dcodeIO.bcrypt;
             let es;
             async function authenticate() {
@@ -224,46 +225,46 @@
 
                 return token;
             }
+
+            const resultListener = function (e) {
+                let data = JSON.parse(e.data);
+                console.log('result', data.event, data);
+            };
+            const scrapeListener = function (e) {
+              console.log('scrape', JSON.parse(e.data));
+            };
+            const errorListener = function (e) {
+              console.error('error', JSON.parse(e.data));
+            };
+            const doneListener = function (e) {
+              console.log('done', JSON.parse(e.data));
+              console.log('There should be no more events after this one. Comment out the `close` line to see if there are any events leaking.');
+              es.close();
+            };
+
             async function searchMovies() {
                 let token = await authenticate();
-                var movieTitle = document.getElementById('movieTitle').value;
+                let movieTitle = document.getElementById('movieTitle').value;
+
+                stop(); // Stop existing eventsource.
                 es = new EventSource(`/api/v1/search/movies?title=${movieTitle}&token=${token}`);
-                es.addEventListener('result', function (e) {
-                    console.log(e.data);
-                });
-                es.addEventListener('scrape', function (e) {
-                    console.log(e.data);
-                });
-                es.addEventListener('error', function (e) {
-                    console.error(e.data);
-                });
-                es.addEventListener('done', function (e) {
-                    console.log(e.data);
-                    console.log('There should be no more events after this one. Comment out the `close` line to see if there are any events leaking.');
-                    es.close();
-                });
+                es.addEventListener('result', resultListener);
+                es.addEventListener('scrape', scrapeListener);
+                es.addEventListener('error', errorListener);
+                es.addEventListener('done', doneListener);
             }
             async function searchTV() {
                 let token = await authenticate();
-                var showTitle = document.getElementById('showTitle').value;
-                var season = document.getElementById('season').value;
-                var episode = document.getElementById('episode').value;
+                let showTitle = document.getElementById('showTitle').value;
+                let season = document.getElementById('season').value;
+                let episode = document.getElementById('episode').value;
 
+                stop(); // Stop existing eventsource.
                 es = new EventSource(`/api/v1/search/tv?title=${showTitle}&season=${season}&episode=${episode}&token=${token}`)
-                es.addEventListener('result', function (e) {
-                    console.log(e.data);
-                });
-                es.addEventListener('scrape', function (e) {
-                    console.log(e.data);
-                });
-                es.addEventListener('error', function (e) {
-                    console.error(e.data);
-                });
-                es.addEventListener('done', function (e) {
-                    console.log(e.data);
-                    console.log('There should be no more events after this one. Comment out the `close` line to see if there are any events leaking.');
-                    es.close();
-                });
+                es.addEventListener('result', resultListener);
+                es.addEventListener('scrape', scrapeListener);
+                es.addEventListener('error', errorListener);
+                es.addEventListener('done', doneListener);
             }
             function stop() {
                 es && es.close();
@@ -273,7 +274,7 @@
                     var code = p.charCodeAt(0).toString(16).toUpperCase();
                     if (code.length < 2) {
                       code = '0' + code;
-                  }
+                    }
                   return '%' + code;
               }));
             }

--- a/server.js
+++ b/server.js
@@ -12,6 +12,11 @@ const pathToApp = __dirname;
 // Initialize express
 let app = express();
 
+// Add renderer.
+app.engine('html', require('ejs').__express);
+app.set('views', 'public'); // render from the public directory.
+app.set('view engine', 'html');
+
 // Load external ExpressJS middleware
 const compression = require('compression');
 
@@ -39,12 +44,12 @@ app.use(function (req, res, next) {
 
 /** RENDERED ROUTES **/
 app.get('/', function(req, res) {
-    if(process.env.NODE_ENV === 'production'){
+    if (process.env.NODE_ENV === 'production') {
         // When in production, redirect to the main site.
         res.redirect("https://apollotv.xyz/");
-    }else {
-        // Otherwise, send index file.
-        res.sendFile(`${pathToApp}/public/index.html`);
+    } else {
+        // Otherwise, render the index file with the secret client id set.
+        res.render('index', {secret_client_id: process.env.SECRET_CLIENT_ID});
     }
 });
 app.get('/bcrypt.js', (req, res) => res.sendFile(`${pathToApp}/public/bcrypt.js`));

--- a/src/scrapers/resolvers/Streamango.js
+++ b/src/scrapers/resolvers/Streamango.js
@@ -2,6 +2,8 @@ const rp = require('request-promise');
 const cheerio = require('cheerio');
 const vm = require('vm');
 
+const normalizeUrl = require('../../utils').normalizeUrl;
+
 async function Streamango(uri, jar, headers) {
     let providerPageHtml = await rp({
         uri,
@@ -14,9 +16,7 @@ async function Streamango(uri, jar, headers) {
 }
 
 function StreamangoHtml(providerPageHtml) {
-    $ = cheerio.load(providerPageHtml);
-
-    let fileId = '';
+    let $ = cheerio.load(providerPageHtml);
 
     const jQuery = function(selector, anotherArg) {
         return {
@@ -40,7 +40,7 @@ function StreamangoHtml(providerPageHtml) {
     vm.createContext(sandbox); // Contextify the sandbox.
     vm.runInContext($('script:contains(srces)')[0].children[0].data.replace('src:d(', 'src:window.d('), sandbox);
 
-    return `https:${sandbox.srces[0].src}`;
+    return normalizeUrl(sandbox.srces[0].src, 'https');
 }
 
 module.exports = exports = {Streamango, StreamangoHtml};

--- a/src/scrapers/resolvers/resolve.js
+++ b/src/scrapers/resolvers/resolve.js
@@ -20,6 +20,7 @@ const StreamM4u = require('./StreamM4u');
 const {GoogleDrive, getGoogleDriveScrapeUrl} = require('./GoogleDrive');
 
 const createEvent = require('../../utils/createEvent');
+const {debugLog} = require('../../utils');
 
 async function resolve(sse, uri, source, jar, headers, quality = '') {
     if (sse.stopExecution) {
@@ -27,7 +28,7 @@ async function resolve(sse, uri, source, jar, headers, quality = '') {
         return;
     }
 
-    console.log(uri);
+    debugLog(`resolving: ${uri}`);
 
     try {
         if (uri.includes('openload.co') || uri.includes('oload.cloud')) {
@@ -192,7 +193,7 @@ async function resolve(sse, uri, source, jar, headers, quality = '') {
             if (link.includes('drive.google.com')) {
                 link = getGoogleDriveScrapeUrl(link);
                 provider = 'GoogleDrive';
-                if (process.env.NODE_ENV === 'production') {
+                if (process.env.CLAWS_ENV === 'server') {
                     ipLocked = true;
                 } else {
                     const dataObjects = await GoogleDrive(link, jar, headers);

--- a/src/utils/createEvent.js
+++ b/src/utils/createEvent.js
@@ -1,7 +1,8 @@
 const URL = require('url');
 
 function createEvent(data, ipLocked, pairing, quality, provider, source, headers) {
-	if (ipLocked) {
+	if (ipLocked && process.env.CLAWS_ENV === 'server') {
+		// The scrape event is only sent when running in server mode.
 		return {
 		    event: 'scrape',
 		    target: pairing.target,

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,8 +1,20 @@
 // Import dependencies
+const url = require('url');
+
 const jwt = require('jsonwebtoken');
 
 // Define utility functions.
+let escapeRegExp = (string) => {
+    return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'); // $& means the whole matched string
+};
+
 module.exports = {
+    debugLog: function () {
+        if (process.env.VERBOSE_LOGGING === 'true') {
+            console.log.apply(null, arguments);
+        }
+    },
+
     /**
      * Used to pad the series and episode numbers.
      * e.g. converts '1' to '01'.
@@ -30,6 +42,48 @@ module.exports = {
             req.userId = decoded.id;
             next();
         });
+    },
+
+  /**
+   * Matches against 'Series', 'Series - 2018', 'Series 2018' and 'Series (2018)'
+   * @param showTitle
+   * @param title
+   * @return {boolean}
+   */
+    isSameSeriesName: (showTitle, title) => {
+        let regex = new RegExp(escapeRegExp(showTitle)+'(?: (?:- )?\\(?\\d{4}\\)?)?$', 'gm');
+        return regex.test(title);
+    },
+
+    /**
+     * Escape a regex string.
+     * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions#Using_special_characters
+     * @param string
+     * @return {void | *}
+     */
+    escapeRegExp: escapeRegExp,
+
+    /**
+     * Resolve a url using a base url, the path is already absolute, then nothing is done.
+     * @param baseUrl
+     * @param path
+     * @return {string}
+     */
+    absoluteUrl: (baseUrl, path) => {
+        return url.resolve(baseUrl, path);
+    },
+
+    /**
+     * Normalize a url in case it's protocol-less.
+     * @param link
+     * @param defaultScheme
+     * @return {*}
+     */
+    normalizeUrl: (link, defaultScheme = 'http') => {
+        if (link.startsWith("//")) {
+            link = `${defaultScheme}:${link}`;
+        }
+        return link;
     },
 
     /**

--- a/src/utils/logger.js
+++ b/src/utils/logger.js
@@ -1,36 +1,39 @@
-const appRoot = require('app-root-path');
 const winston = require('winston');
 
-const options = {
-    file: {
-        level: 'info',
-        filename: `${appRoot}/logs/app.log`,
-        handleExceptions: true,
-        json: true,
-        maxsize: 5242880,
-        maxFiles: 5,
-        colorize: false,
-    },
-    console: {
+const winstonTransports = [
+    new winston.transports.Console({
         level: 'debug',
         handleExceptions: true,
         json: false,
         colorize: true,
-    },
-};
+    }),
+];
+
+if (process.env.CLAWS_ENV === 'server') {
+    // The client-side scraper doesn't need a log file or the app-root-path module.
+    const appRoot = require('app-root-path');
+    winstonTransports.push(
+        new winston.transports.File({
+            level: 'info',
+            filename: `${appRoot}/logs/app.log`,
+            handleExceptions: true,
+            json: true,
+            maxsize: 5242880,
+            maxFiles: 5,
+            colorize: false,
+        })
+    );
+}
 
 const logger = winston.createLogger({
-    transports: [
-        new winston.transports.File(options.file),
-        new winston.transports.Console(options.console)
-    ],
+    transports: winstonTransports,
     exitOnError: false, // do not exit on handled exceptions
 });
 
 // create a stream object with a 'write' function that will be used by `morgan`
 logger.stream = {
     write: function (message, encoding) {
-        // use the 'info' log level so the output will be picked up by both transports (file and console)
+        // use the 'info' log level so the output will be picked up by all the available transports (file and console)
         logger.info(message);
     },
 };


### PR DESCRIPTION
- During development, inject the client secret into the html using `ejs`.
- logger.js: don't include the filesystem logger when running in client mode.
- Only send the scrape event when running in server mode.
- Scraper bug fixes and general improvements. It now fails gracefully when it's unable to resolve certain links, no more pollution of the console logs with null-pointer exceptions.
- Also fixed an issue with the event-source leaking because `res.end()` wasn't called.


Once this is merged, your server will need to specify `CLAWS_ENV="server"` in its `.env` file to keep working as expected.