### PR TITLE
feature(provider): temporarily add MasterAnime as universal provider

### DIFF
--- a/src/api/resolveLinks.js
+++ b/src/api/resolveLinks.js
@@ -41,12 +41,12 @@ const resolveLinks = async (data, ws, req) => {
     req.query = {...data, type};
 
     // Get available providers.
-    let availableProviders;
+    let availableProviders = [...providers[type], ...providers.universal];
+
+    // Add anime providers if Anime tag sent from client. 
+    // TODO: Add and send this tag from the client
     if (type === 'anime') {
-        // The universal provider won't work with animes.
-        availableProviders = [...providers[type]]
-    } else {
-        availableProviders = [...providers[type], ...providers.universal];
+        availableProviders.push([...providers.anime]);
     }
 
     availableProviders.forEach((provider) => {

--- a/src/scrapers/providers/index.js
+++ b/src/scrapers/providers/index.js
@@ -20,6 +20,7 @@ module.exports = exports = {
     ],
     universal: [
         require('./universal/123movie'),
+        new (require('./anime/MasterAnime'))(),
         //require('./universal/5movies')
     ]
 };


### PR DESCRIPTION
## feature(provider): temporarily add MasterAnime as universal provider

Add `MasterAnime` to the `universal` providers **(temporarily)** and add logic to add anime providers only if `anime` is sent as `type` from the client.

### What's in this PR:
- Refactor logic in `resolveLinks.js` to do as described with staff:
  > Use Anime, TV/Movie and Universal providers if the show / movie is Anime.
  > Use TV/Movie and Universal providers is show / movie is not Anime.
- Add `MasterAnime` to Universal providers for now (temporary - see note)


### Note:
As the client is not set up to currently send `anime` to Claws, when an anime show is currently searched, no links are returned. This is because Claws was only adding `MasterAnime` as a source if `anime` was sent as type. The only types currently sent by the client are `tv` / `movie`.

To fix this, and return links for anime shows until a `type:anime` is supported in the client, I am temporarily adding `MasterAnime` to `universal` providers as these are always used. When `anime` is supported from the client, this will be removed.
