### PR TITLE
refactor(series8): update series8 to use BaseProvider class

### DIFF
--- a/src/scrapers/providers/BaseProvider.js
+++ b/src/scrapers/providers/BaseProvider.js
@@ -3,6 +3,7 @@ const querystring = require('querystring');
 const Promise = require('bluebird');
 const RequestPromise = require('request-promise');
 const resolve = require('../resolvers/resolve');
+const logger = require('../../utils/logger');
 
 function _implementMe(functionName) {
     throw new Error(`Must implement ${functionName}()`);
@@ -16,6 +17,8 @@ function _implementMe(functionName) {
  */
 const BaseProvider = class BaseProvider {
     constructor() {
+        this.logger = logger;
+
         if (new.target === BaseProvider) {
             throw new TypeError("Cannot construct BaseProvider instances directly");
         }
@@ -174,7 +177,7 @@ const BaseProvider = class BaseProvider {
                 options: e.options,
             }
         }
-        console.error(`${this.getProviderId()}: An unexpected error occurred:`, e);
+        this.logger.error(`${this.getProviderId()}: An unexpected error occurred:`, e);
     }
 };
 

--- a/src/scrapers/providers/index.js
+++ b/src/scrapers/providers/index.js
@@ -12,8 +12,8 @@ module.exports = exports = {
         require('./tv/GoWatchSeries'),
         require('./tv/SeriesFree'),
         require('./tv/AfdahTV'),
-        require('./tv/Series8'),
         require('./tv/SwatchSeries'),
+        new (require('./tv/series8'))()
     ],
     anime: [
         new (require('./anime/MasterAnime'))(),

--- a/src/scrapers/providers/tv/Series8.js
+++ b/src/scrapers/providers/tv/Series8.js
@@ -1,6 +1,6 @@
 const cheerio = require('cheerio');
 const randomUseragent = require('random-useragent');
-const { absoluteUrl, getClientIp, removeYearFromTitle } = require('../../../utils');
+const { absoluteUrl, removeYearFromTitle } = require('../../../utils');
 const BaseProvider = require('../BaseProvider');
 
 module.exports = class Series8 extends BaseProvider {
@@ -11,7 +11,7 @@ module.exports = class Series8 extends BaseProvider {
 
     /** @inheritdoc */
     async scrape(url, req, ws) {
-        const clientIp = getClientIp(req);
+        const clientIp = this._getClientIp(req);
         const showTitle = req.query.title.toLowerCase();
         const season = req.query.season;
         const episode = req.query.episode;

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -91,14 +91,6 @@ module.exports = {
         return new Promise(resolve => setTimeout(resolve, ms));
     },
 
-     /**
-     * returns formatted clientId
-     * @param req request sent to server.
-     */
-    getClientIp: (req) => { 
-        req.client.remoteAddress.replace('::ffff:', '').replace('::1', '') 
-    },
-
     /**
      * removes year from string ie: title (2019) -> title
      * @param title title including year to be removed.

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -104,7 +104,6 @@ module.exports = {
      * @param title title including year to be removed.
      */
     removeYearFromTitle: (title) => {
-        console.log(title)
         return title.replace(/\s\([0-9]{4}\)$/, "");
     }
 };

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -89,5 +89,22 @@ module.exports = {
      */
     timeout: (ms) => {
         return new Promise(resolve => setTimeout(resolve, ms));
+    },
+
+     /**
+     * returns formatted clientId
+     * @param req request sent to server.
+     */
+    getClientIp: (req) => { 
+        req.client.remoteAddress.replace('::ffff:', '').replace('::1', '') 
+    },
+
+    /**
+     * removes year from string ie: title (2019) -> title
+     * @param title title including year to be removed.
+     */
+    removeYearFromTitle: (title) => {
+        console.log(title)
+        return title.replace(/\s\([0-9]{4}\)$/, "");
     }
 };


### PR DESCRIPTION
## refactor(series8): update series8 to use BaseProvider class

Update Series8 to use the BaseProvider class.

### What's in this PR:
- Refactor the `Series8 ` provider to use the `BaseProvider` class.
- Add logging functionality into `BaseProvider` to be used by adding`this.logger.<level>`
- Add new util functions:
  > removeYearFromTitle: remove year from a show title, ie: title (2019) -> title

  > getClientIp: returns client ip from `req` object in a formatted way for requests.