### PR TITLE
refactor(swatchseries): refactor swatchseries to  follow BaseProvider structure

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -180,6 +180,7 @@
         </div>
         <div class="searchFilter">
             <input id="showTitle" type="text" placeholder="show" />
+            <input id="year" type="text" placeholder="year" />
             <input id="season" type="text" placeholder="season" />
             <input id="episode" type="text" placeholder="episode" />
             <label for="isAnime">Is Anime<input id="isAnime" type="checkbox"></label>
@@ -269,6 +270,7 @@
                 let showTitle = document.getElementById('showTitle').value;
                 let season = document.getElementById('season').value;
                 let episode = document.getElementById('episode').value;
+                let year = document.getElementById('year').value;
                 let isAnime = document.getElementById('isAnime').checked;
 
                 stop(); // Stop existing eventsource.
@@ -279,6 +281,7 @@
                         {
                             'type': isAnime ? 'anime' : 'tv',
                             'title': showTitle,
+                            'year': year,
                             'season': season,
                             'episode': episode
                         }

--- a/src/scrapers/providers/index.js
+++ b/src/scrapers/providers/index.js
@@ -12,7 +12,7 @@ module.exports = exports = {
         require('./tv/GoWatchSeries'),
         require('./tv/SeriesFree'),
         require('./tv/AfdahTV'),
-        require('./tv/SwatchSeries'),
+        new (require('./tv/SwatchSeries'))(),
         new (require('./tv/series8'))()
     ],
     anime: [

--- a/src/scrapers/providers/index.js
+++ b/src/scrapers/providers/index.js
@@ -11,7 +11,6 @@ module.exports = exports = {
     tv: [
         require('./tv/GoWatchSeries'),
         require('./tv/SeriesFree'),
-        require('./tv/AfdahTV'),
         new (require('./tv/SwatchSeries'))(),
         new (require('./tv/series8'))()
     ],

--- a/src/scrapers/providers/tv/SwatchSeries.js
+++ b/src/scrapers/providers/tv/SwatchSeries.js
@@ -3,49 +3,37 @@ const RequestPromise = require('request-promise');
 const cheerio = require('cheerio');
 const randomUseragent = require('random-useragent');
 const URL = require('url');
-const logger = require('../../../utils/logger');
+const { absoluteUrl, removeYearFromTitle } = require('../../../utils');
+const BaseProvider = require('../BaseProvider');
 
-const resolve = require('../../resolvers/resolve');
+module.exports = class SwatchSeries extends BaseProvider {
+    /** @inheritdoc */
+    getUrls() {
+        return ["https://www1.swatchseries.to"];
+    }
 
-async function SwatchSeries(req, sse) {
-    const clientIp = req.client.remoteAddress.replace('::ffff:', '').replace('::1', '')
-    const showTitle = req.query.title;
-    const {season, episode} = req.query;
-
-    const urls = ["https://www1.swatchseries.to"];
-    const promises = [];
-
-    const rp = RequestPromise.defaults(target => {
-        if (sse.stopExecution) {
-            return null;
-        }
-
-        return RequestPromise(target);
-    });
-
-    // Go to each url and scrape for links, then send the link to the client
-    async function scrape(url) {
+    /** @inheritdoc */
+    async scrape(url, req, ws) {
+        const showTitle = req.query.title;
+        const year = req.query.year;
+        const season = req.query.season
+        const episode = req.query.episode;
+        const searchTitle = showTitle.replace(/\s+/g, '%20').toLowerCase();
+        const searchUrl = `${url}/search/${searchTitle}`;
+        const rp = this._getRequest(req, ws);
+        const jar = rp.jar();
         const resolvePromises = [];
+        const clientIp = this._getClientIp(req);
 
         try {
-            const jar = rp.jar();
-            const userAgent = randomUseragent.getRandom();
-            const html = await rp({
-                uri: `${url}/search/${showTitle.replace(/ \(.*\)/, '').replace(/ /, '%20')}`,
-                headers: {
-                    'user-agent': userAgent,
-                    referer: url
-                },
-                jar,
-                timeout: 5000
+            const response = await this._createRequest(rp, searchUrl, jar, {
+                'user-agent': randomUseragent.getRandom(),
+                referer: url
             });
-
-            let $ = cheerio.load(html);
-
+            let $ = cheerio.load(response);
             let showUrl = '';
-
             $(`a strong`).toArray().some(element => {
-                if ($(element).text() === showTitle) {
+                if ($(element).text() === `${showTitle} (${year})`) {
                     showUrl = $(element).parent().attr('href');
                     return true;
                 }
@@ -54,58 +42,28 @@ async function SwatchSeries(req, sse) {
 
             if (!showUrl) {
                 // Don't attempt to make requests on empty URLs.
+                this.logger.debug(`${this.getProviderId()} - no urls found for ${showTitle}`)
                 return Promise.all(resolvePromises);
             }
-
-            const videoPageHtml = await rp({
-                uri: showUrl,
-                headers: {
-                    'user-agent': userAgent
-                },
-                jar,
-                timeout: 5000
-            });
+            const videoPageHtml = await this._createRequest(rp, showUrl);
 
             $ = cheerio.load(videoPageHtml);
-
             const episodeUrl = $(`a[href*="s${season}_e${episode}."]`).attr('href');
-
-            const episodePageHtml = await rp({
-                uri: episodeUrl,
-                headers: {
-                    'user-agent': userAgent
-                },
-                jar,
-                timeout: 5000
-            });
+            const episodePageHtml = await this._createRequest(rp, episodeUrl);
 
             $ = cheerio.load(episodePageHtml);
-
             const videoUrls = $('.watchlink').toArray().map(element => URL.parse($(element).attr('href') || '', true).query.r).filter(url => !!url).map(url => Buffer.from(url, 'base64').toString());
-
-            videoUrls.forEach(async (providerUrl) => {
+            videoUrls.forEach(async (link) => {
                 const headers = {
-                    'user-agent': userAgent,
+                    'user-agent': randomUseragent.getRandom(),
                     'x-real-ip': clientIp,
                     'x-forwarded-for': clientIp
                 };
-                resolvePromises.push(resolve(sse, providerUrl, 'SwatchSeries', jar, headers));
+                resolvePromises.push(this.resolveLink(link, ws, jar, headers));
             });
         } catch (err) {
-            if (!sse.stopExecution) {
-                logger.error({source: 'SwatchSeries', sourceUrl: url, query: {title: req.query.title, season: req.query.season, episode: req.query.episode}, error: (err.message || err.toString()).substring(0, 100) + '...'});
-            }
+            this._onErrorOccurred(err);
         }
-
         return Promise.all(resolvePromises);
     }
-
-    // Asynchronously start all the scrapers for each url
-    urls.forEach((url) => {
-        promises.push(scrape(url));
-    });
-
-    return Promise.all(promises);
 }
-
-module.exports = exports = SwatchSeries;


### PR DESCRIPTION
## refactor(swatchseries): refactor swatchseriesto follow BaseProvider structure

Update SwatchSeries to use the BaseProvider class.

### What's in this PR:
- Refactor the `SwatchSeries  ` provider to use the `BaseProvider` class.
- Add `year` field to the test html page.

### Note: This PR relies on the [Kamino PR](https://github.com/ApolloTVofficial/kamino/pull/123) to be merged before adding `year` as a parameter to the request. Do Not Merge this PR before that is complete.