### PR TITLE
fix(seriesfree): url is not defined

### DIFF
--- a/src/scrapers/providers/tv/SeriesFree.js
+++ b/src/scrapers/providers/tv/SeriesFree.js
@@ -49,7 +49,7 @@ async function SeriesFree(req, sse) {
             return resolve(sse, providerUrl, 'SeriesFree', jar, headers);
         } catch (err) {
             if (!sse.stopExecution) {
-                logger.error({source: 'SeriesFree', sourceUrl: url, query: {title: req.query.title, season: req.query.season, episode: req.query.episode}, error: (err.message || err.toString()).substring(0, 100) + '...'});
+                logger.error({source: 'SeriesFree', sourceUrl: videoUrl, query: {title: req.query.title, season: req.query.season, episode: req.query.episode}, error: (err.message || err.toString()).substring(0, 100) + '...'});
             }
         }
     }


### PR DESCRIPTION
## fix(seriesfree): url is not defined

### What's in this PR:

Fix console error:
`url is not defined`

This error was happening in some cases, and when it did, the `done` event failed to send as there was an error in the promise resolution.