### PR TITLE
fix(BFMovies): fix logger in BFMovies

### DIFF
--- a/src/scrapers/providers/movies/bfmovies.js
+++ b/src/scrapers/providers/movies/bfmovies.js
@@ -45,7 +45,7 @@ module.exports = class bfmovies extends BaseProvider {
             
             let openloadPage = $("iframe").attr('src');
             if(!openloadPage.includes("openload")){
-                logger.debug("BFMovies does not always use OpenLoad.");
+                this.logger.debug("BFMovies does not always use OpenLoad.");
                 return false;
             }
             const openloadHTML = await this._createRequest(rp, openloadPage);


### PR DESCRIPTION
## fix(BFMovies): fix logger in BFMovies

Update BFMovies debug log to use correct logger.

### What's in this PR:
- Change `logger` to `this.logger` in debug log.
