### PR TITLE
feat(baseprovider): small baseprovider improvements

### DIFF
--- a/src/scrapers/providers/BaseProvider.js
+++ b/src/scrapers/providers/BaseProvider.js
@@ -4,6 +4,7 @@ const Promise = require('bluebird');
 const RequestPromise = require('request-promise');
 const resolve = require('../resolvers/resolve');
 const logger = require('../../utils/logger');
+const randomUseragent = require('random-useragent');
 
 function _implementMe(functionName) {
     throw new Error(`Must implement ${functionName}()`);
@@ -18,6 +19,7 @@ function _implementMe(functionName) {
 const BaseProvider = class BaseProvider {
     constructor() {
         this.logger = logger;
+        this.userAgent = randomUseragent.getRandom();        
 
         if (new.target === BaseProvider) {
             throw new TypeError("Cannot construct BaseProvider instances directly");
@@ -44,11 +46,11 @@ const BaseProvider = class BaseProvider {
      * Scrape the URL
      * @param url
      * @param req
-     * @param sse
+     * @param ws
      *
      * @return Promise Usually.
      */
-    scrape(url, req, sse) {
+    scrape(url, req, ws) {
         _implementMe('scrape');
     }
 
@@ -57,30 +59,44 @@ const BaseProvider = class BaseProvider {
      * Should be called by the `scrape` function when it finds a link that needs resolving.
      *
      * @param link
-     * @param sse
+     * @param ws
      * @param jar
      * @param headers
      * @param quality
      * @return {Promise<undefined|*|void>}
      */
-    resolveLink(link, sse, jar, headers, quality = '') {
-        return resolve(sse, link, this.getProviderId(), jar, headers, quality);
+    resolveLink(link, ws, jar, headers, quality = '') {
+        return resolve(ws, link, this.getProviderId(), jar, headers, quality);
     }
 
     /**
      * Resolve requests.
      * @param req
-     * @param sse
+     * @param ws
      * @return {Array}
      */
-    resolveRequests(req, sse) {
-        const promises = [];
+    resolveRequests(req, ws) {
+        // Set instance variables that depend on `req` or `ws`
+        this._setInstanceVariables(req, ws);
+        
         // Asynchronously start all the scrapers for each url
+        const promises = [];
         this.getUrls().forEach((url) => {
-                promises.push(this.scrape(url, req, sse));
+                promises.push(this.scrape(url, req, ws));
         });
 
         return Promise.all(promises);
+    }
+
+    /**
+     * Set variables on each Provider to be re-used throughout the providers logic
+     * @param req
+     * @param ws
+     * @returns void
+     */
+    _setInstanceVariables(req, ws) {
+        this.clientIp = this._getClientIp(req);
+        this.rp = this._getRequest(req, ws);
     }
 
     /**
@@ -96,12 +112,12 @@ const BaseProvider = class BaseProvider {
      * Return the default request promise object to use for all requests.
      *
      * @param req
-     * @param sse
+     * @param ws
      * @return Function
      */
-    _getRequest(req, sse) {
+    _getRequest(req, ws) {
         return RequestPromise.defaults(target => {
-            if (sse.stopExecution) {
+            if (ws.stopExecution) {
                 return null;
             }
 


### PR DESCRIPTION
## feat(baseprovider): small baseprovider improvements

Cleanup BaseProvider variable name, add some instance variables that can be re-used across other providers in a cleaner way.

### What's in this PR:
- Rename `sse` to `ws` in `BaseProvider` class.
- Add `randomUserAgent`, `rp` and `clientIp` to `BaseProvider` to allow for better reuse within other providers.
