### PR TITLE
resolveLinks: Remove old-style provider support

### DIFF
--- a/src/api/resolveLinks.js
+++ b/src/api/resolveLinks.js
@@ -50,13 +50,7 @@ const resolveLinks = async (searchData, ws, req) => {
     }
 
     availableProviders.forEach((provider) => {
-        if (provider instanceof BaseProvider) {
-            // Use object orientated provider.
             return promises.push(provider.resolveRequests(req, sse));
-        } else {
-            // Use declarative provider.
-            return promises.push(provider(req, sse));
-        }
     });
 
     await Promise.all(promises);


### PR DESCRIPTION
All providers are now reworked to extend BaseProvider, and all future ones should follow that