### PR TITLE
Client scrape options

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -139,6 +139,7 @@
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.5.tgz",
       "integrity": "sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==",
+      "dev": true,
       "requires": {
         "jsonparse": "^1.2.0",
         "through": ">=2.2.7 <3"
@@ -556,15 +557,6 @@
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.12.0.tgz",
       "integrity": "sha512-DYWGk01lDcxeS/K9IHPGWfT8PsJmbXRtRd2Sx72Tnb8pcYZQFF1oSDb8hJtS1vhp212q1Rzi5dUf9+nq0o9UIg==",
       "dev": true
-    },
-    "bl": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
-      "integrity": "sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==",
-      "requires": {
-        "readable-stream": "^2.3.5",
-        "safe-buffer": "^5.1.1"
-      }
     },
     "blessed": {
       "version": "0.1.81",
@@ -1541,14 +1533,6 @@
       "integrity": "sha512-urQxA1smbLZ2cBbXbaYObM1dJ82aJ2H57A1C/Kklfh/ZN1bgH4G/n5KWhdNfOK11W98gqZfyYj7W4frJJRwA2w==",
       "dev": true
     },
-    "deferential": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/deferential/-/deferential-1.0.0.tgz",
-      "integrity": "sha1-9IHJXithoSHIqrnWtB944EVECX0=",
-      "requires": {
-        "native-promise-only": "^0.8.1"
-      }
-    },
     "define-property": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
@@ -2200,16 +2184,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fecha/-/fecha-2.3.3.tgz",
       "integrity": "sha512-lUGBnIamTAwk4znq5BcqsDaxSmZ9nDVJaij6NvRt/Tg4R69gERA+otPKbS86ROw9nxVMw2/mp1fnaiWqbs6Sdg=="
-    },
-    "ffprobe": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/ffprobe/-/ffprobe-1.1.0.tgz",
-      "integrity": "sha1-9k8OpE4zyA/B967+MfxLNwfSrM4=",
-      "requires": {
-        "JSONStream": "^1.0.7",
-        "bl": "^1.0.0",
-        "deferential": "^1.0.0"
-      }
     },
     "ffprobe-static": {
       "version": "3.0.0",
@@ -3663,7 +3637,8 @@
     "jsonparse": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
-      "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA="
+      "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=",
+      "dev": true
     },
     "jsonwebtoken": {
       "version": "8.4.0",
@@ -4238,11 +4213,6 @@
         "snapdragon": "^0.8.1",
         "to-regex": "^3.0.1"
       }
-    },
-    "native-promise-only": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/native-promise-only/-/native-promise-only-0.8.1.tgz",
-      "integrity": "sha1-IKMYwwy0X3H+et+/eyHJnBRy7xE="
     },
     "needle": {
       "version": "2.2.4",
@@ -5775,7 +5745,8 @@
     "through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+      "dev": true
     },
     "through2": {
       "version": "2.0.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -139,7 +139,6 @@
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.5.tgz",
       "integrity": "sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==",
-      "dev": true,
       "requires": {
         "jsonparse": "^1.2.0",
         "through": ">=2.2.7 <3"
@@ -557,6 +556,15 @@
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.12.0.tgz",
       "integrity": "sha512-DYWGk01lDcxeS/K9IHPGWfT8PsJmbXRtRd2Sx72Tnb8pcYZQFF1oSDb8hJtS1vhp212q1Rzi5dUf9+nq0o9UIg==",
       "dev": true
+    },
+    "bl": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
+      "integrity": "sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==",
+      "requires": {
+        "readable-stream": "^2.3.5",
+        "safe-buffer": "^5.1.1"
+      }
     },
     "blessed": {
       "version": "0.1.81",
@@ -1533,6 +1541,14 @@
       "integrity": "sha512-urQxA1smbLZ2cBbXbaYObM1dJ82aJ2H57A1C/Kklfh/ZN1bgH4G/n5KWhdNfOK11W98gqZfyYj7W4frJJRwA2w==",
       "dev": true
     },
+    "deferential": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/deferential/-/deferential-1.0.0.tgz",
+      "integrity": "sha1-9IHJXithoSHIqrnWtB944EVECX0=",
+      "requires": {
+        "native-promise-only": "^0.8.1"
+      }
+    },
     "define-property": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
@@ -2184,6 +2200,21 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fecha/-/fecha-2.3.3.tgz",
       "integrity": "sha512-lUGBnIamTAwk4znq5BcqsDaxSmZ9nDVJaij6NvRt/Tg4R69gERA+otPKbS86ROw9nxVMw2/mp1fnaiWqbs6Sdg=="
+    },
+    "ffprobe": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/ffprobe/-/ffprobe-1.1.0.tgz",
+      "integrity": "sha1-9k8OpE4zyA/B967+MfxLNwfSrM4=",
+      "requires": {
+        "JSONStream": "^1.0.7",
+        "bl": "^1.0.0",
+        "deferential": "^1.0.0"
+      }
+    },
+    "ffprobe-static": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/ffprobe-static/-/ffprobe-static-3.0.0.tgz",
+      "integrity": "sha512-LZ1Sj4RHS95t/ReZtRbCmMEWDDl7cfIMwmhNgCZcdtOgRlAHaGGOupoc166Q9AV+T7lXnUvu5HYczcsn69c6fw=="
     },
     "file-uri-to-path": {
       "version": "1.0.0",
@@ -3632,8 +3663,7 @@
     "jsonparse": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
-      "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=",
-      "dev": true
+      "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA="
     },
     "jsonwebtoken": {
       "version": "8.4.0",
@@ -4208,6 +4238,11 @@
         "snapdragon": "^0.8.1",
         "to-regex": "^3.0.1"
       }
+    },
+    "native-promise-only": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/native-promise-only/-/native-promise-only-0.8.1.tgz",
+      "integrity": "sha1-IKMYwwy0X3H+et+/eyHJnBRy7xE="
     },
     "needle": {
       "version": "2.2.4",
@@ -5740,8 +5775,7 @@
     "through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
-      "dev": true
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
     },
     "through2": {
       "version": "2.0.5",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,8 @@
     "dotenv": "^6.2.0",
     "ejs": "^2.6.1",
     "express": "^4.16.4",
+    "ffprobe": "^1.1.0",
+    "ffprobe-static": "^3.0.0",
     "js-salsa20": "^1.0.0",
     "jsonwebtoken": "^8.4.0",
     "m3u8-stream-list": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "dotenv": "^6.2.0",
     "ejs": "^2.6.1",
     "express": "^4.16.4",
-    "ffprobe": "^1.1.0",
     "ffprobe-static": "^3.0.0",
     "js-salsa20": "^1.0.0",
     "jsonwebtoken": "^8.4.0",

--- a/public/index.html
+++ b/public/index.html
@@ -26,6 +26,10 @@
                 font-family: "Roboto", sans-serif;
             }
 
+            label {
+                color: white;
+            }
+
             .material-button-raised {
                 position: relative;
                 display: inline-block;
@@ -206,7 +210,7 @@
         </noscript>
 
         <div class="searchBox">
-            <input id="searchText" type="text" placeholder="Enter a movie..." />
+            <input id="searchText" type="text" placeholder="Search for something..." />
             <br><br><br>
             <button type="button" class="material-button-raised primary" onclick="search()">Search</button>
             <button id="stop" type="button" class="material-button-raised red" disabled onclick="stop()">Stop Scraping</button>

--- a/public/index.html
+++ b/public/index.html
@@ -273,7 +273,7 @@
 
             async function scrapeMovies(searchData) {
                 let token = await authenticate();
-                stop(); // Stop existing eventsource.
+                stop(); // Stop existing websocket.
                 ws = new WebSocket(`ws://localhost:3000/?token=${token}`);
                 ws.onopen = function() {
                     // Web Socket is connected, send data using send()
@@ -302,7 +302,7 @@
             }
             async function scrapeTV(searchData) {
                 let token = await authenticate();
-                stop(); // Stop existing eventsource.
+                stop(); // Stop existing websocket.
                 ws = new WebSocket(`ws://localhost:3000/?token=${token}`);
                 let isAnime = document.getElementById('isAnime').checked;
                 ws.onopen = function() {

--- a/src/api/resolveLinks.js
+++ b/src/api/resolveLinks.js
@@ -5,10 +5,12 @@ const providers = require('../scrapers/providers');
 
 const BaseProvider = require('../scrapers/providers/BaseProvider');
 
+const WsWrapper = require('../utils/WsWrapper');
+
 /**
  * Sends the current time in milliseconds.
  */
-const sendInitialStatus = (sse) => sse.send({ data: [`${new Date().getTime()}`], event: 'status'}, 'result');
+const sendInitialStatus = (ws) => ws.send(JSON.stringify({data: [`${new Date().getTime()}`], event: 'status'}));
 
 /**
  * Return request handler for certain media types.
@@ -17,45 +19,35 @@ const sendInitialStatus = (sse) => sse.send({ data: [`${new Date().getTime()}`],
  * @param req request
  * @return {Function}
  */
-const resolveLinks = async (searchData, ws, req) => {
-    const type = searchData.type;
-    const sse = {
-        send: (resultData) => {
-            try {
-                ws.send(JSON.stringify(resultData));
-            } catch (err) {
-                console.log("WS client disconnected, can't send data");
-            }
-        },
-        stopExecution: false
-    };
+const resolveLinks = async (data, ws, req) => {
+    const type = data.type;
 
-    sendInitialStatus(sse);
+    sendInitialStatus(ws);
+
+    const wsWrapper = new WsWrapper(ws, data.options);
 
     ws.on('close', () => {
-        sse.stopExecution = true;
+        wsWrapper.stopExecution = true;
     });
 
     const promises = [];
 
-    req.query = searchData;
+    req.query = data;
 
     // Get available providers.
     let availableProviders = [...providers[type], ...providers.universal];
 
-    // Add anime providers if Anime tag sent from client. 
+    // Add anime providers if Anime tag sent from client.
     // TODO: Add and send this tag from the client
     if (type === 'anime') {
         availableProviders.push([...providers.anime]);
     }
 
-    availableProviders.forEach((provider) => {
-            return promises.push(provider.resolveRequests(req, sse));
-    });
+    availableProviders.forEach((provider) => promises.push(provider.resolveRequests(req, wsWrapper)));
 
     await Promise.all(promises);
 
-    sse.send({event: 'done'}, 'done');
+    wsWrapper.send({event: 'done'}, 'done');
 };
 
 module.exports = resolveLinks;

--- a/src/api/resolveLinks.js
+++ b/src/api/resolveLinks.js
@@ -47,7 +47,7 @@ const resolveLinks = async (data, ws, req) => {
 
     await Promise.all(promises);
 
-    wsWrapper.send({event: 'done'}, 'done');
+    ws.send({event: 'done'});
 };
 
 module.exports = resolveLinks;

--- a/src/api/resolveLinks.js
+++ b/src/api/resolveLinks.js
@@ -47,7 +47,7 @@ const resolveLinks = async (data, ws, req) => {
 
     await Promise.all(promises);
 
-    ws.send({event: 'done'});
+    ws.send(JSON.stringify({event: 'done'}));
 };
 
 module.exports = resolveLinks;

--- a/src/scrapers/providers/BaseProvider.js
+++ b/src/scrapers/providers/BaseProvider.js
@@ -19,7 +19,7 @@ function _implementMe(functionName) {
 const BaseProvider = class BaseProvider {
     constructor() {
         this.logger = logger;
-        this.userAgent = randomUseragent.getRandom();        
+        this.userAgent = randomUseragent.getRandom();
 
         if (new.target === BaseProvider) {
             throw new TypeError("Cannot construct BaseProvider instances directly");
@@ -78,7 +78,7 @@ const BaseProvider = class BaseProvider {
     resolveRequests(req, ws) {
         // Set instance variables that depend on `req` or `ws`
         this._setInstanceVariables(req, ws);
-        
+
         // Asynchronously start all the scrapers for each url
         const promises = [];
         this.getUrls().forEach((url) => {

--- a/src/scrapers/providers/archive/anime/MasterAnime.js
+++ b/src/scrapers/providers/archive/anime/MasterAnime.js
@@ -8,7 +8,7 @@ module.exports = class MasterAnime extends BaseProvider {
     }
 
     /** @inheritdoc */
-    async scrape(url, req, sse) {
+    async scrape(url, req, ws) {
         const title = req.query.title;
         const season = req.query.season;
         const episode = req.query.episode;
@@ -22,7 +22,7 @@ module.exports = class MasterAnime extends BaseProvider {
                 sb: 'true'
             });
 
-            const rp = this._getRequest(req, sse);
+            const rp = this._getRequest(req, ws);
             let response = await this._createRequest(rp, searchUrl);
             let animes = JSON.parse(response);
             for (let i = 0; i < animes.length; i++) {
@@ -36,7 +36,7 @@ module.exports = class MasterAnime extends BaseProvider {
                         if (currentEpisode['info']['episode'] === episode + '') {
                             let seriesHtml = await this._createRequest(rp, `${url}/anime/watch/${anime['slug']}/${currentEpisode['info']['episode']}`);
                             this._scrapeMirrors(seriesHtml, (link, quality) => {
-                                resolvePromises.push(this.resolveLink(link, sse, null, null, quality));
+                                resolvePromises.push(this.resolveLink(link, ws, null, null, quality));
                             });
                         }
                     }

--- a/src/scrapers/providers/movies/Afdah.js
+++ b/src/scrapers/providers/movies/Afdah.js
@@ -117,7 +117,7 @@ module.exports = class Afdah extends BaseProvider {
 
                 // const link = sandbox.window.srcs[0].url;
                 // const event = createEvent(link, false, {}, {quality: '', provider: 'Vidlink', source: 'Afdah'});
-                // sse.send(event, event.event);
+                // await ws.send(event, event.event);
                 // } catch(err) {
                 headers = {
                     accept: 'text/html, */*; q=0.01',

--- a/src/scrapers/providers/movies/Afdah.js
+++ b/src/scrapers/providers/movies/Afdah.js
@@ -116,7 +116,7 @@ module.exports = class Afdah extends BaseProvider {
                 // vm.runInContext(cleanedObfuscatedSources, sandbox);
 
                 // const link = sandbox.window.srcs[0].url;
-                // const event = createEvent(link, false, {}, {quality: '', provider: 'Vidlink', source: 'Afdah'});
+                // const event = createEvent(link, false, {}, {quality: '', source: 'Vidlink', provider: 'Afdah'});
                 // await ws.send(event, event.event);
                 // } catch(err) {
                 headers = {

--- a/src/scrapers/providers/movies/GoStream.js
+++ b/src/scrapers/providers/movies/GoStream.js
@@ -3,14 +3,13 @@
 
 const RequestPromise = require('request-promise');
 const cheerio = require('cheerio');
-const tough = require('tough-cookie');
 const randomUseragent = require('random-useragent');
 const logger = require('../../../utils/logger')
 
 const {timeout} = require('../../../utils');
 const resolve = require('../../resolvers/resolve');
 
-async function GoStream(req, sse) {
+async function GoStream(req, ws) {
     const clientIp = req.client.remoteAddress.replace('::ffff:', '').replace('::1', '');
     const movieTitle = req.query.title;
 
@@ -19,7 +18,7 @@ async function GoStream(req, sse) {
     const promises = [];
 
     const rp = RequestPromise.defaults(target => {
-        if (sse.stopExecution) {
+        if (ws.stopExecution) {
             return null;
         }
 

--- a/src/scrapers/providers/movies/MovieFiles.js
+++ b/src/scrapers/providers/movies/MovieFiles.js
@@ -1,14 +1,13 @@
 const Promise = require('bluebird');
 const RequestPromise = require('request-promise');
 const cheerio = require('cheerio');
-const tough = require('tough-cookie');
 const randomUseragent = require('random-useragent');
 const logger = require('../../../utils/logger')
 
 const {escapeRegExp} = require('../../../utils');
 const resolve = require('../../resolvers/resolve');
 
-async function MovieFiles(req, sse) {
+async function MovieFiles(req, ws) {
     const clientIp = req.client.remoteAddress.replace('::ffff:', '').replace('::1', '');
     const movieTitle = req.query.title;
     const year = req.query.year;
@@ -18,7 +17,7 @@ async function MovieFiles(req, sse) {
     const promises = [];
 
     const rp = RequestPromise.defaults(target => {
-        if (sse.stopExecution) {
+        if (ws.stopExecution) {
             return null;
         }
 
@@ -56,11 +55,11 @@ async function MovieFiles(req, sse) {
                     const qualityExp = new RegExp(`${escapeRegExp(modifiedSearchTitle)}\\.${year}\\.[^\\d]*(\\d\\d\\d\\d?p)`);
                     const qualityExec = qualityExp.exec(foundTitle);
                     const quality = qualityExec ? qualityExec[1] : '';
-                    resolvePromises.push(resolve(sse, providerUrl, 'MovieFiles', jar, headers, quality));
+                    resolvePromises.push(resolve(ws, providerUrl, 'MovieFiles', jar, headers, quality));
                 }
             });
         } catch (err) {
-            if (!sse.stopExecution) {
+            if (!ws.stopExecution) {
                 logger.error({source: 'MovieFiles', sourceUrl: url, query: {title: req.query.title}, error: (err.message || err.toString()).substring(0, 100) + '...'});
             }
         }

--- a/src/scrapers/providers/movies/MovieFiles.js
+++ b/src/scrapers/providers/movies/MovieFiles.js
@@ -60,7 +60,7 @@ async function MovieFiles(req, ws) {
             });
         } catch (err) {
             if (!ws.stopExecution) {
-                logger.error({source: 'MovieFiles', sourceUrl: url, query: {title: req.query.title}, error: (err.message || err.toString()).substring(0, 100) + '...'});
+                logger.error({provider: 'MovieFiles', providerUrl: url, query: {title: req.query.title}, error: (err.message || err.toString()).substring(0, 100) + '...'});
             }
         }
 

--- a/src/scrapers/providers/movies/bfmovies.js
+++ b/src/scrapers/providers/movies/bfmovies.js
@@ -13,16 +13,16 @@ module.exports = class bfmovies extends BaseProvider {
         const year = req.query.year;
         const resolvePromises = [];
         let headers = {};
-    
+
         try {
             const searchTitle = `${title} (${year})`;
             let searchUrl = (`${url}/search?q=${searchTitle.replace(/ /g, '+')}`);
             const rp = this._getRequest(req, ws);
             const jar = rp.jar();
             const response = await this._createRequest(rp, searchUrl, jar, headers);
-            
+
             let $ = cheerio.load(response);
-            
+
             let videoPage = '';
             $(`li[itemtype="http://schema.org/Movie"]`).toArray().forEach(element => {
                 let linkElement = $(element).find("a");
@@ -42,7 +42,7 @@ module.exports = class bfmovies extends BaseProvider {
             const videoPageHTML = await this._createRequest(rp, videoPage, jar, headers);
 
             $ = cheerio.load(videoPageHTML);
-            
+
             let openloadPage = $("iframe").attr('src');
             if(!openloadPage.includes("openload")){
                 this.logger.debug("BFMovies does not always use OpenLoad.");

--- a/src/scrapers/providers/tv/AfdahTV.js
+++ b/src/scrapers/providers/tv/AfdahTV.js
@@ -10,7 +10,7 @@ const logger = require('../../../utils/logger')
 const resolve = require('../../resolvers/resolve');
 const {padTvNumber} = require('../../../utils');
 
-async function AfdahTV(req, sse) {
+async function AfdahTV(req, ws) {
     const clientIp = req.client.remoteAddress.replace('::ffff:', '').replace('::1', '');
     const title = req.query.name;
     const season = padTvNumber(req.query.season);
@@ -20,7 +20,7 @@ async function AfdahTV(req, sse) {
     const promises = [];
 
     const rp = RequestPromise.defaults(target => {
-        if (sse.stopExecution) {
+        if (ws.stopExecution) {
             return null;
         }
 
@@ -124,11 +124,11 @@ async function AfdahTV(req, sse) {
                         let decode = tor(Buffer.from(tor(code), 'base64').toString('ascii'));
                         let providerRegex = /(?:src=')(.*)(?:' scrolling)/g.exec(decode);
                         if (providerRegex) {
-                            resolvePromises.push(resolve(sse, providerRegex[1], 'AfdahTV', jar));
+                            resolvePromises.push(resolve(ws, providerRegex[1], 'AfdahTV', jar));
                         } else {
                             decode = Buffer.from(tor(Buffer.from(code, 'base64').toString('ascii')), 'base64').toString('ascii');
                             providerRegex = /(?:src=')(.*)(?:' scrolling)/g.exec(decode);
-                            resolvePromises.push(resolve(sse, providerRegex[1], 'AfdahTV', jar));
+                            resolvePromises.push(resolve(ws, providerRegex[1], 'AfdahTV', jar));
                         }
                     });
             } else {
@@ -148,7 +148,7 @@ async function AfdahTV(req, sse) {
     //                 // await page.screenshot({path: 'AfdahTV.png'});
     //                 const videoSourceUrl = await page.evaluate(() => window.player && window.player.getPlaylist()[0].file);
     //                 console.log(videoSourceUrl);
-    //                 sse.send({videoSourceUrl, url, provider}, 'result');
+    //                 await ws.send({videoSourceUrl, url, provider}, 'result');
     //             }
     //
     //             sourceIds.filter(sourceId => !sourceId.startsWith('/trailer')).forEach(sourceId => {
@@ -156,7 +156,7 @@ async function AfdahTV(req, sse) {
     //             });
             }
         } catch (err) {
-            if (!sse.stopExecution) {
+            if (!ws.stopExecution) {
                 logger.error({source: 'AfdahTV', sourceUrl: url, query: {title: req.query.name, season: req.query.season, episode: req.query.episode}, error: (err.message || err.toString()).substring(0, 100) + '...'});
             }
         }

--- a/src/scrapers/providers/tv/AfdahTV.js
+++ b/src/scrapers/providers/tv/AfdahTV.js
@@ -157,7 +157,7 @@ async function AfdahTV(req, ws) {
             }
         } catch (err) {
             if (!ws.stopExecution) {
-                logger.error({source: 'AfdahTV', sourceUrl: url, query: {title: req.query.name, season: req.query.season, episode: req.query.episode}, error: (err.message || err.toString()).substring(0, 100) + '...'});
+                logger.error({provider: 'AfdahTV', providerUrl: url, query: {title: req.query.name, season: req.query.season, episode: req.query.episode}, error: (err.message || err.toString()).substring(0, 100) + '...'});
             }
         }
 

--- a/src/scrapers/providers/tv/GoWatchSeries.js
+++ b/src/scrapers/providers/tv/GoWatchSeries.js
@@ -4,7 +4,7 @@ const randomUseragent = require('random-useragent');
 const { padTvNumber } = require('../../../utils');
 const BaseProvider = require('../BaseProvider');
 
-module.exports = class SwatchSeries extends BaseProvider {
+module.exports = class GoWatchSeries extends BaseProvider {
     /** @inheritdoc */
     getUrls() {
         return ['https://gowatchseries.co'];
@@ -84,7 +84,7 @@ module.exports = class SwatchSeries extends BaseProvider {
                 };
                 resolvePromises.push(this.resolveLink(link, ws, jar, headers));
             });
-            
+
         } catch (err) {
             this._onErrorOccurred(err);
         }

--- a/src/scrapers/providers/tv/SeriesFree.js
+++ b/src/scrapers/providers/tv/SeriesFree.js
@@ -3,7 +3,7 @@ const cheerio = require('cheerio');
 const randomUseragent = require('random-useragent');
 const BaseProvider = require('../BaseProvider');
 
-module.exports = class extends BaseProvider {
+module.exports = class SeriesFree extends BaseProvider {
     /** @inheritdoc */
     getUrls() {
         return ['https://seriesfree.to'];

--- a/src/scrapers/providers/universal/123movie.js
+++ b/src/scrapers/providers/universal/123movie.js
@@ -1,7 +1,6 @@
 const cheerio = require('cheerio');
 const randomUseragent = require('random-useragent');
 const BaseProvider = require('../BaseProvider');
-const tough = require('tough-cookie');
 
 module.exports = class _123movie extends BaseProvider {
     /** @inheritdoc */

--- a/src/scrapers/providers/universal/5movies.js
+++ b/src/scrapers/providers/universal/5movies.js
@@ -5,7 +5,7 @@ const logger = require('../../../utils/logger')
 
 const resolve = require('../../resolvers/resolve');
 
-async function _5movies(req, sse){
+async function _5movies(req, ws){
     logger.debug("5movies NOTICE: This primitively removes the year from the end of the title. If this source breaks, did you change the title parameter?");
     let showTitle = req.query.title || req.query.name;
     showTitle = showTitle.substr(0, showTitle.length - 7);
@@ -17,7 +17,7 @@ async function _5movies(req, sse){
     const promises = [];
 
     const rp = RequestPromise.defaults(target => {
-        if (sse.stopExecution) {
+        if (ws.stopExecution) {
             return null;
         }
 
@@ -89,9 +89,9 @@ async function _5movies(req, sse){
         console.log(rapidVideoURL);
 
         const jar = rp.jar();
-        return Promise.all([resolve(sse, rapidVideoURL, '123Movie', jar, {})]);*/
+        return Promise.all([resolve(ws, rapidVideoURL, '123Movie', jar, {})]);*/
         const jar = rp.jar();
-        return Promise.all([resolve(sse, enterVideoURL, '5movies', jar, {})]);
+        return Promise.all([resolve(ws, enterVideoURL, '5movies', jar, {})]);
     }
 
     urls.forEach((url) => {

--- a/src/scrapers/resolvers/AfdahTV.js
+++ b/src/scrapers/resolvers/AfdahTV.js
@@ -38,7 +38,7 @@ async function AfdahTV(uri, jar, headers) {
     const providerUrl = /(?:src=')(.*)(?:' scrolling)/g.exec(decode)[1];
 
     const videoSourceUrl = await Openload(providerUrl, jar);
-    sse.send({videoSourceUrl, url, provider: 'https://openload.co', ipLocked: true}, 'result');
+    await ws.send({videoSourceUrl, url, provider: 'https://openload.co', ipLocked: true}, 'result');
 }
 
 module.exports = exports = AfdahTV;

--- a/src/scrapers/resolvers/_BaseResolver.js
+++ b/src/scrapers/resolvers/_BaseResolver.js
@@ -11,7 +11,6 @@ function _implementMe(functionName) {
  * @property {String|null} quality The link quality
  * @property {String|null} provider The provider's name (human readable)
  * @property {String|null} source The source that uploaded the content to the provider (human readable)
- * @property {Boolean|null} isDownload Whether this source is download only.
  * @property {String|null} cookieRequired The name of the cookie required by the client.
  * @property {String|null} cookie The cookie to pass along to the client.
  */
@@ -73,7 +72,7 @@ const BaseResolver = class BaseResolver {
     /**
      * Resolve a URI.
      * @param {Object} meta The meta data for resolving requests.
-     * @param {Object} meta.sse server-side emitter/websocket agent.
+     * @param {Object} meta.ws server-side emitter/websocket agent.
      * @param {String} meta.source The source that initiated the request (Usually the provider ID).
      * @param {String} meta.quality The quality of the current request.
      * @param {String} uri
@@ -93,7 +92,7 @@ const BaseResolver = class BaseResolver {
     /**
      * Resolve an html file.
      * @param {Object} meta The meta data for resolving requests.
-     * @param {Object?} meta.sse server-side emitter/websocket agent. Only available when resolving on the server-side.
+     * @param {Object?} meta.ws server-side emitter/websocket agent. Only available when resolving on the server-side.
      * @param {String} meta.source The source that initiated the request.
      * @param {String} meta.quality The quality of the current request.
      * @param html
@@ -130,23 +129,23 @@ const BaseResolver = class BaseResolver {
      *
      * @param {ClawsMetadata} metaData
      * @param {ClawsLink[]} links
-     * @return {Array}
+     * @return {Promise<Array>}
      */
-    processHtmlResults(metaData, links) {
-        if (metaData.sse) {
-            if (metaData.sse.stopExecution) {
+    async processHtmlResults(metaData, links) {
+        if (metaData.ws) {
+            if (metaData.ws.stopExecution) {
                 console.log(`${this.getResolverId()}: Skip resolve due to disconnect. This should rarely ever happen!`);
                 return links;
             }
 
             // Emitting resources directly from the server.
-            links.forEach(link => {
+            for (let link of links) {
                 const event = this.createEvent(link.data, false, undefined, {
                     quality: link.meta.quality || metaData.quality,
                     source: metaData.source
                 });
-                metaData.sse.send(event, event.event);
-            });
+                await metaData.ws.send(event, event.event);
+            }
             return links;
         } else {
             // Returning links directly from HTMl.

--- a/src/scrapers/resolvers/_BaseResolver.js
+++ b/src/scrapers/resolvers/_BaseResolver.js
@@ -142,7 +142,7 @@ const BaseResolver = class BaseResolver {
             for (let link of links) {
                 const event = this.createEvent(link.data, false, undefined, {
                     quality: link.meta.quality || metaData.quality,
-                    source: metaData.source
+                    provider: metaData.provider
                 });
                 await metaData.ws.send(event, event.event);
             }
@@ -168,8 +168,8 @@ const BaseResolver = class BaseResolver {
      * @return {Object} The event object.
      */
     createEvent(data, ipLocked, pairing, metaData, headers) {
-        if (!metaData['provider']) {
-            metaData['provider'] = this.getResolverId();
+        if (!metaData['source']) {
+            metaData['source'] = this.getResolverId();
         }
         return createEvent(data, ipLocked, pairing, metaData, headers);
     }
@@ -179,12 +179,12 @@ const BaseResolver = class BaseResolver {
      * @see scrapeFromClientResponse
      *
      * @param {String} uri The uri for the current resolver.
-     * @param {{quality: String, source: String}|ClawsMetadata} metaData The request metadata.
+     * @param {{quality: String, provider: String}|ClawsMetadata} metaData The request metadata.
      *
      * @return {Object}
      */
     createScrapeEvent(uri, metaData) {
-        return this.createEvent(undefined, true, {target: uri}, {quality: metaData.quality, source: metaData.source})
+        return this.createEvent(undefined, true, {target: uri}, {quality: metaData.quality, provider: metaData.provider})
     }
 
     /**

--- a/src/scrapers/resolvers/resolve.js
+++ b/src/scrapers/resolvers/resolve.js
@@ -35,8 +35,8 @@ const resolvers = [
     new TikiWiki(),
 ];
 
-async function resolve(sse, uri, source, jar, headers, quality = '') {
-    if (sse.stopExecution) {
+async function resolve(ws, uri, source, jar, headers, quality = '') {
+    if (ws.stopExecution) {
         logger.debug('Skip resolve due to disconnect');
         return;
     }
@@ -52,13 +52,13 @@ async function resolve(sse, uri, source, jar, headers, quality = '') {
             if (resolver.supportsUri(uri)) {
                 logger.debug(`${resolver.getResolverId()} supports ${uri}!`);
                 return await resolver.resolveUri({
-                    sse,
+                    ws,
                     source,
                     quality
                 }, uri, jar, headers);
             }
         }
-        // TODO move all the resolvers below into their own subclasses for better code maintenance.
+        // TODO move all the resolvers below into their own subclawss for better code maintenance.
         // Same logic should apply to resolveHtml.js.
 
         if (uri.includes('openload.co') || uri.includes('oload.cloud')) {
@@ -72,7 +72,7 @@ async function resolve(sse, uri, source, jar, headers, quality = '') {
                 data = await Openload(uri, jar, headers);
             }
             const event = createEvent(data, ipLocked, {url: 'https://olpair.com', videoId, target: uri}, {quality, provider: 'Openload', source});
-            sse.send(event, event.event);
+            await ws.send(event, event.event);
 
         } else if (uri.includes('streamango.com')) {
             let data;
@@ -80,23 +80,23 @@ async function resolve(sse, uri, source, jar, headers, quality = '') {
                 data = await Streamango(uri, jar, headers);
             }
             const event = createEvent(data, ipLocked, {target: uri}, {quality, provider: 'Streamango', source});
-            sse.send(event, event.event);
+            await ws.send(event, event.event);
 
         } else if (uri.includes('rapidvideo.com')) {
             const data = await RapidVideo(uri, jar);
             const event = createEvent(data, false, undefined, {quality, provider: 'RapidVideo', source});
-            sse.send(event, event.event);
+            await ws.send(event, event.event);
 
         } else if (uri.includes('azmovies.co') || uri.includes('azmovies.ws')) {
             const file = await AZMovies(uri, jar, headers);
             const event = createEvent(file, false, undefined, {quality, provider: 'AZMovies', source});
-            sse.send(event, event.event);
+            await ws.send(event, event.event);
 
         } else if (uri.includes('vidlox.me') || uri.includes('vidlox.tv')) {
             const dataList = await Vidlox(uri, jar, headers);
             for (const data of dataList) {
                 const event = createEvent(data, false, undefined, {quality, provider: 'Vidlox', source}, {referer: uri});
-                sse.send(event, event.event);
+                await ws.send(event, event.event);
             }
 
         } else if (uri.includes('vshare.eu')) {
@@ -111,7 +111,7 @@ async function resolve(sse, uri, source, jar, headers, quality = '') {
                 data = await VShare(uri, jar, headers);
             }
             const event = createEvent(data, ipLocked, {url: 'https://vshare.eu/pair', videoId, target: uri}, {quality, provider: 'VShare', source});
-            sse.send(event, event.event);
+            await ws.send(event, event.event);
 
         } else if (uri.includes('speedvid.net')) {
             if (!uri.includes('embed')) {
@@ -122,7 +122,7 @@ async function resolve(sse, uri, source, jar, headers, quality = '') {
             const dataList = await SpeedVid(uri, jar, headers);
             for (const data of dataList) {
                 const event = createEvent(data, false, undefined, {quality, provider: 'SpeedVid', source});
-                sse.send(event, event.event);
+                await ws.send(event, event.event);
             }
 
         } else if (uri.includes('vidcloud.co')) {
@@ -134,26 +134,26 @@ async function resolve(sse, uri, source, jar, headers, quality = '') {
             const dataObjects = await VidCloud(uri, jar, headers);
             for(dataObject of dataObjects){
                 const event = createEvent(!!dataObject.file ? dataObject.file : dataObject.link, false, undefined, {quality, provider: 'VidCloud', source});
-                sse.send(event, event.event);
+                await ws.send(event, event.event);
             }
 
         } else if (uri.includes('clipwatching.com')) {
             const dataObjects = await ClipWatching(uri, jar, headers);
             for (const dataObject of dataObjects) {
                 const event = createEvent(dataObject.file, false, undefined, {quality: dataObject.label || quality, provider: 'ClipWatching', source});
-                sse.send(event, event.event);
+                await ws.send(event, event.event);
             }
 
         } else if (uri.includes('estream.to') || uri.includes('estream.xyz')) {
             // const path = uri.split('/');
             // const videoId = path[path.length - 1];
             // const videoSourceUrls = await EStream(`http://estream.xyz/embed-${videoId}`, jar, clientIp, userAgent);
-            // videoSourceUrls.forEach(source => sse.send({videoSourceUrl: source, url, provider: 'http://estream.xyz'}, 'result'));
+            // videoSourceUrls.forEach(source => await ws.send({videoSourceUrl: source, url, provider: 'http://estream.xyz'}, 'result'));
             // // All the links are broken...
 
         } else if (uri.includes('vidzi.online')) {
             // const sources = await Vidzi(uri, jar, clientIp, userAgent);
-            // sources.forEach((source) => sse.send({videoSourceUrl: source.file, url, provider: 'https://vidzi.online'}, 'result'));
+            // sources.forEach((source) => await ws.send({videoSourceUrl: source.file, url, provider: 'https://vidzi.online'}, 'result'));
             // // All the links are broken...
 
         } else if (uri.includes('vidto.me')) {
@@ -166,7 +166,7 @@ async function resolve(sse, uri, source, jar, headers, quality = '') {
             const dataObjects = await VidTodo(uri, jar, headers);
             for (const dataObject of dataObjects) {
                 const event = createEvent(dataObject.file, false, undefined, {quality: dataObject.label || quality, provider: 'VidTodo', source}, {referer: uri.replace('vidtodo.me', 'vidstodo.me')});
-                sse.send(event, event.event);
+                await ws.send(event, event.event);
             }
 
         } else if (uri.includes('powvideo.net')) {
@@ -181,11 +181,11 @@ async function resolve(sse, uri, source, jar, headers, quality = '') {
                 dataObjects = await PowVideo(uri, jar, headers, videoId);
                 for (const dataObject of dataObjects) {
                     const event = createEvent(!!dataObject.file ? dataObject.file : dataObject.link, false, undefined, {quality, provider: 'PowVideo', source});
-                    sse.send(event, event.event);
+                    await ws.send(event, event.event);
                 }
             } else {
                 const event = createEvent(undefined, true, {target: uri, headers: {referer: `https://povwideo.cc/preview-${videoId}-954x562.html`}}, {quality, provider: 'PowVideo', source});
-                sse.send(event, event.event);
+                await ws.send(event, event.event);
             }
 
         } else if (uri.includes('streamplay.to')) {
@@ -197,11 +197,11 @@ async function resolve(sse, uri, source, jar, headers, quality = '') {
                 dataList = await GamoVideo(uri, jar, headers);
                 for (const data of dataList) {
                     const event = createEvent(data, false, undefined, {quality, provider: 'GamoVideo', source});
-                    sse.send(event, event.event);
+                    await ws.send(event, event.event);
                 }
             } else {
                 const event = createEvent(undefined, true, {target: uri}, {quality, provider: 'GamoVideo', source});
-                sse.send(event, event.event);
+                await ws.send(event, event.event);
             }
 
 
@@ -209,21 +209,21 @@ async function resolve(sse, uri, source, jar, headers, quality = '') {
             const dataObjects = await GorillaVid(uri, jar, headers);
             for (const dataObject of dataObjects) {
                 const event = createEvent(dataObject.src, false, undefined, {quality, provider: 'GorillaVid', source});
-                sse.send(event, event.event);
+                await ws.send(event, event.event);
             }
 
         } else if (uri.includes('daclips.com') || uri.includes('daclips.in')) {
             const dataObjects = await DaClips(uri, jar, headers);
             for (const dataObject of dataObjects) {
                 const event = createEvent(dataObject.src, false, undefined, {quality, provider: 'DaClips', source});
-                sse.send(event, event.event);
+                await ws.send(event, event.event);
             }
 
         } else if (uri.includes('movpod.com') || uri.includes('movpod.in')) {
             const dataObjects = await MovPod(uri, jar, headers);
             for (const dataObject of dataObjects) {
                 const event = createEvent(dataObject.src, false, undefined, {quality, provider: 'MovPod', source});
-                sse.send(event, event.event);
+                await ws.send(event, event.event);
             }
 
         } else if (uri.includes('vidoza.net')) {
@@ -237,16 +237,16 @@ async function resolve(sse, uri, source, jar, headers, quality = '') {
                 dataObjects = await Vidoza(uri, jar, headers);
                 for (const dataObject of dataObjects) {
                     const event = createEvent(dataObject.src, false, undefined, {quality: dataObject.res || quality, provider: 'Vidoza', source});
-                    sse.send(event, event.event);
+                    await ws.send(event, event.event);
                 }
             } else {
                 const event = createEvent(undefined, true, {target: uri}, {quality, provider: 'Vidoza', source});
-                sse.send(event, event.event);
+                await ws.send(event, event.event);
             }
 
         } else if (uri.includes('streamm4u.com')) {
             let link = await StreamM4u(uri, jar, headers);
-            resolve(sse, link, source, jar, headers, quality);
+            resolve(ws, link, source, jar, headers, quality);
 
         // TODO: Commenting this out until header/cookie support exists for the player.
         } else if (uri.includes('drive.google.com')) {
@@ -260,22 +260,22 @@ async function resolve(sse, uri, source, jar, headers, quality = '') {
                 const cookie = cookieValue ? `DRIVE_STREAM=${cookieValue}` : undefined;
                 for (const dataObject of dataObjects) {
                     const event = createEvent(dataObject.link, false, undefined, {quality: dataObject.quality || quality, provider: 'GoogleDrive', source, cookie});
-                    sse.send(event, event.event);
+                    await ws.send(event, event.event);
                 }
             } else {
                 const event = createEvent(undefined, true, {target: uri}, {quality, provider: 'GoogleDrive', source, cookieRequired: 'DRIVE_STREAM'});
-                sse.send(event, event.event);
+                await ws.send(event, event.event);
             }
 
         } else if (uri.includes('moviefiles.org')) {
             const data = await MovieFiles(uri, jar, headers);
-            const event = createEvent(data, false, undefined, {quality, provider: 'MovieFiles', source, isDownload: true});
-            sse.send(event, event.event);
+            const event = createEvent(data, false, undefined, {quality, provider: 'MovieFiles', source});
+            await ws.send(event, event.event);
 
        /* } else if (uri.includes('entervideo.net')) {
             const data = await EnterVideo(uri, jar, headers);
             const event = createEvent(data, false, undefined, {quality, provider: 'EnterVideo', source});
-            sse.send(event, event.event);*/
+            await ws.send(event, event.event);*/
         } else {
             logger.warn({source, providerUrl: uri, warning: 'Missing resolver'});
         }

--- a/src/scrapers/resolvers/resolve.js
+++ b/src/scrapers/resolvers/resolve.js
@@ -35,7 +35,7 @@ const resolvers = [
     new TikiWiki(),
 ];
 
-async function resolve(ws, uri, source, jar, headers, quality = '') {
+async function resolve(ws, uri, provider, jar, headers, quality = '') {
     if (ws.stopExecution) {
         logger.debug('Skip resolve due to disconnect');
         return;
@@ -53,7 +53,7 @@ async function resolve(ws, uri, source, jar, headers, quality = '') {
                 logger.debug(`${resolver.getResolverId()} supports ${uri}!`);
                 return await resolver.resolveUri({
                     ws,
-                    source,
+                    provider,
                     quality
                 }, uri, jar, headers);
             }
@@ -71,7 +71,7 @@ async function resolve(ws, uri, source, jar, headers, quality = '') {
             if (!ipLocked) {
                 data = await Openload(uri, jar, headers);
             }
-            const event = createEvent(data, ipLocked, {url: 'https://olpair.com', videoId, target: uri}, {quality, provider: 'Openload', source});
+            const event = createEvent(data, ipLocked, {url: 'https://olpair.com', videoId, target: uri}, {quality, source: 'Openload', provider});
             await ws.send(event, event.event);
 
         } else if (uri.includes('streamango.com')) {
@@ -79,23 +79,23 @@ async function resolve(ws, uri, source, jar, headers, quality = '') {
             if (!ipLocked) {
                 data = await Streamango(uri, jar, headers);
             }
-            const event = createEvent(data, ipLocked, {target: uri}, {quality, provider: 'Streamango', source});
+            const event = createEvent(data, ipLocked, {target: uri}, {quality, source: 'Streamango', provider});
             await ws.send(event, event.event);
 
         } else if (uri.includes('rapidvideo.com')) {
             const data = await RapidVideo(uri, jar);
-            const event = createEvent(data, false, undefined, {quality, provider: 'RapidVideo', source});
+            const event = createEvent(data, false, undefined, {quality, source: 'RapidVideo', provider});
             await ws.send(event, event.event);
 
         } else if (uri.includes('azmovies.co') || uri.includes('azmovies.ws')) {
             const file = await AZMovies(uri, jar, headers);
-            const event = createEvent(file, false, undefined, {quality, provider: 'AZMovies', source});
+            const event = createEvent(file, false, undefined, {quality, source: 'AZMovies', provider});
             await ws.send(event, event.event);
 
         } else if (uri.includes('vidlox.me') || uri.includes('vidlox.tv')) {
             const dataList = await Vidlox(uri, jar, headers);
             for (const data of dataList) {
-                const event = createEvent(data, false, undefined, {quality, provider: 'Vidlox', source}, {referer: uri});
+                const event = createEvent(data, false, undefined, {quality, source: 'Vidlox', provider}, {referer: uri});
                 await ws.send(event, event.event);
             }
 
@@ -110,7 +110,7 @@ async function resolve(ws, uri, source, jar, headers, quality = '') {
             if (!ipLocked) {
                 data = await VShare(uri, jar, headers);
             }
-            const event = createEvent(data, ipLocked, {url: 'https://vshare.eu/pair', videoId, target: uri}, {quality, provider: 'VShare', source});
+            const event = createEvent(data, ipLocked, {url: 'https://vshare.eu/pair', videoId, target: uri}, {quality, source: 'VShare', provider});
             await ws.send(event, event.event);
 
         } else if (uri.includes('speedvid.net')) {
@@ -121,7 +121,7 @@ async function resolve(ws, uri, source, jar, headers, quality = '') {
             }
             const dataList = await SpeedVid(uri, jar, headers);
             for (const data of dataList) {
-                const event = createEvent(data, false, undefined, {quality, provider: 'SpeedVid', source});
+                const event = createEvent(data, false, undefined, {quality, source: 'SpeedVid', provider});
                 await ws.send(event, event.event);
             }
 
@@ -133,14 +133,14 @@ async function resolve(ws, uri, source, jar, headers, quality = '') {
             }
             const dataObjects = await VidCloud(uri, jar, headers);
             for(dataObject of dataObjects){
-                const event = createEvent(!!dataObject.file ? dataObject.file : dataObject.link, false, undefined, {quality, provider: 'VidCloud', source});
+                const event = createEvent(!!dataObject.file ? dataObject.file : dataObject.link, false, undefined, {quality, source: 'VidCloud', provider});
                 await ws.send(event, event.event);
             }
 
         } else if (uri.includes('clipwatching.com')) {
             const dataObjects = await ClipWatching(uri, jar, headers);
             for (const dataObject of dataObjects) {
-                const event = createEvent(dataObject.file, false, undefined, {quality: dataObject.label || quality, provider: 'ClipWatching', source});
+                const event = createEvent(dataObject.file, false, undefined, {quality: dataObject.label || quality, source: 'ClipWatching', provider});
                 await ws.send(event, event.event);
             }
 
@@ -165,7 +165,7 @@ async function resolve(ws, uri, source, jar, headers, quality = '') {
         } else if (uri.includes('vidtodo.me') || uri.includes('vidtodo.com') || uri.includes('vidstodo.me')) {
             const dataObjects = await VidTodo(uri, jar, headers);
             for (const dataObject of dataObjects) {
-                const event = createEvent(dataObject.file, false, undefined, {quality: dataObject.label || quality, provider: 'VidTodo', source}, {referer: uri.replace('vidtodo.me', 'vidstodo.me')});
+                const event = createEvent(dataObject.file, false, undefined, {quality: dataObject.label || quality, source: 'VidTodo', provider}, {referer: uri.replace('vidtodo.me', 'vidstodo.me')});
                 await ws.send(event, event.event);
             }
 
@@ -180,11 +180,11 @@ async function resolve(ws, uri, source, jar, headers, quality = '') {
             if (!ipLocked) {
                 dataObjects = await PowVideo(uri, jar, headers, videoId);
                 for (const dataObject of dataObjects) {
-                    const event = createEvent(!!dataObject.file ? dataObject.file : dataObject.link, false, undefined, {quality, provider: 'PowVideo', source});
+                    const event = createEvent(!!dataObject.file ? dataObject.file : dataObject.link, false, undefined, {quality, source: 'PowVideo', provider});
                     await ws.send(event, event.event);
                 }
             } else {
-                const event = createEvent(undefined, true, {target: uri, headers: {referer: `https://povwideo.cc/preview-${videoId}-954x562.html`}}, {quality, provider: 'PowVideo', source});
+                const event = createEvent(undefined, true, {target: uri, headers: {referer: `https://povwideo.cc/preview-${videoId}-954x562.html`}}, {quality, source: 'PowVideo', provider});
                 await ws.send(event, event.event);
             }
 
@@ -196,11 +196,11 @@ async function resolve(ws, uri, source, jar, headers, quality = '') {
             if (!ipLocked) {
                 dataList = await GamoVideo(uri, jar, headers);
                 for (const data of dataList) {
-                    const event = createEvent(data, false, undefined, {quality, provider: 'GamoVideo', source});
+                    const event = createEvent(data, false, undefined, {quality, source: 'GamoVideo', provider});
                     await ws.send(event, event.event);
                 }
             } else {
-                const event = createEvent(undefined, true, {target: uri}, {quality, provider: 'GamoVideo', source});
+                const event = createEvent(undefined, true, {target: uri}, {quality, source: 'GamoVideo', provider});
                 await ws.send(event, event.event);
             }
 
@@ -208,21 +208,21 @@ async function resolve(ws, uri, source, jar, headers, quality = '') {
         } else if (uri.includes('gorillavid.com') || uri.includes('gorillavid.in')) {
             const dataObjects = await GorillaVid(uri, jar, headers);
             for (const dataObject of dataObjects) {
-                const event = createEvent(dataObject.src, false, undefined, {quality, provider: 'GorillaVid', source});
+                const event = createEvent(dataObject.src, false, undefined, {quality, source: 'GorillaVid', provider});
                 await ws.send(event, event.event);
             }
 
         } else if (uri.includes('daclips.com') || uri.includes('daclips.in')) {
             const dataObjects = await DaClips(uri, jar, headers);
             for (const dataObject of dataObjects) {
-                const event = createEvent(dataObject.src, false, undefined, {quality, provider: 'DaClips', source});
+                const event = createEvent(dataObject.src, false, undefined, {quality, source: 'DaClips', provider});
                 await ws.send(event, event.event);
             }
 
         } else if (uri.includes('movpod.com') || uri.includes('movpod.in')) {
             const dataObjects = await MovPod(uri, jar, headers);
             for (const dataObject of dataObjects) {
-                const event = createEvent(dataObject.src, false, undefined, {quality, provider: 'MovPod', source});
+                const event = createEvent(dataObject.src, false, undefined, {quality, source: 'MovPod', provider});
                 await ws.send(event, event.event);
             }
 
@@ -236,17 +236,17 @@ async function resolve(ws, uri, source, jar, headers, quality = '') {
             if (!ipLocked) {
                 dataObjects = await Vidoza(uri, jar, headers);
                 for (const dataObject of dataObjects) {
-                    const event = createEvent(dataObject.src, false, undefined, {quality: dataObject.res || quality, provider: 'Vidoza', source});
+                    const event = createEvent(dataObject.src, false, undefined, {quality: dataObject.res || quality, source: 'Vidoza', provider});
                     await ws.send(event, event.event);
                 }
             } else {
-                const event = createEvent(undefined, true, {target: uri}, {quality, provider: 'Vidoza', source});
+                const event = createEvent(undefined, true, {target: uri}, {quality, source: 'Vidoza', provider});
                 await ws.send(event, event.event);
             }
 
         } else if (uri.includes('streamm4u.com')) {
             let link = await StreamM4u(uri, jar, headers);
-            resolve(ws, link, source, jar, headers, quality);
+            resolve(ws, link, provider, jar, headers, quality);
 
         // TODO: Commenting this out until header/cookie support exists for the player.
         } else if (uri.includes('drive.google.com')) {
@@ -259,28 +259,28 @@ async function resolve(ws, uri, source, jar, headers, quality = '') {
                 const cookieValue = cookieObject ? cookieObject.value : false;
                 const cookie = cookieValue ? `DRIVE_STREAM=${cookieValue}` : undefined;
                 for (const dataObject of dataObjects) {
-                    const event = createEvent(dataObject.link, false, undefined, {quality: dataObject.quality || quality, provider: 'GoogleDrive', source, cookie});
+                    const event = createEvent(dataObject.link, false, undefined, {quality: dataObject.quality || quality, source: 'GoogleDrive', provider, cookie});
                     await ws.send(event, event.event);
                 }
             } else {
-                const event = createEvent(undefined, true, {target: uri}, {quality, provider: 'GoogleDrive', source, cookieRequired: 'DRIVE_STREAM'});
+                const event = createEvent(undefined, true, {target: uri}, {quality, source: 'GoogleDrive', provider, cookieRequired: 'DRIVE_STREAM'});
                 await ws.send(event, event.event);
             }
 
         } else if (uri.includes('moviefiles.org')) {
             const data = await MovieFiles(uri, jar, headers);
-            const event = createEvent(data, false, undefined, {quality, provider: 'MovieFiles', source});
+            const event = createEvent(data, false, undefined, {quality, source: 'MovieFiles', provider});
             await ws.send(event, event.event);
 
        /* } else if (uri.includes('entervideo.net')) {
             const data = await EnterVideo(uri, jar, headers);
-            const event = createEvent(data, false, undefined, {quality, provider: 'EnterVideo', source});
+            const event = createEvent(data, false, undefined, {quality, source: 'EnterVideo', provider});
             await ws.send(event, event.event);*/
         } else {
-            logger.warn({source, providerUrl: uri, warning: 'Missing resolver'});
+            logger.warn({provider, providerUrl: uri, warning: 'Missing resolver'});
         }
     } catch(err) {
-        logger.error({source, providerUrl: uri, error: (err.message || err.toString()).substring(0, 100) + '...'});
+        logger.error({provider, providerUrl: uri, error: (err.message || err.toString()).substring(0, 100) + '...'});
     }
 }
 

--- a/src/utils/WsWrapper.js
+++ b/src/utils/WsWrapper.js
@@ -1,0 +1,114 @@
+const RequestPromise = require('request-promise');
+const tough = require('tough-cookie');
+const ffprobe = require('ffprobe');
+const ffprobeStatic = require('ffprobe-static');
+
+class WsWrapper {
+    constructor(ws, options) {
+        this.ws = ws;
+        this.options = options;
+
+        this.stopExecution = false
+        this.rp = RequestPromise.defaults(target => {
+            if (this.stopExecution) {
+                return null;
+            }
+
+            return RequestPromise(target);
+        })
+
+        this.sentLinks = [];
+    }
+
+    async send(resultData) {
+        if (this.shouldSend(resultData)) {
+            await this.setHeadInfo(resultData);
+            // await this.setMetaInfo(resultData);
+            try {
+                this.ws.send(JSON.stringify(resultData));
+                this.sentLinks.push(resultData.file.data);
+            } catch (err) {
+                console.log("WS client disconnected, can't send data");
+            }
+        }
+    }
+
+    shouldSend(resultData) {
+        if (resultData.event === 'result') {
+            return !this.sentLinks.includes(resultData.file.data);
+        } else {
+            return !this.sentLinks.includes(resultData.target);
+        }
+    }
+
+    async setHeadInfo(resultData) {
+        if (resultData.event === 'result') {
+            const jar = this.rp.jar();
+            const headers = resultData.headers || {};
+
+            if (resultData.metadata.cookie) {
+                const splitCookie = resultData.metadata.cookie.split('=');
+                const cookie = new tough.Cookie({
+                    key: splitCookie[0],
+                    value: splitCookie[1]
+                });
+                jar.setCookie(cookie, resultData.file.data);
+            }
+
+            try {
+                const response = await this.rp({
+                    uri: resultData.file.data,
+                    method: 'HEAD',
+                    headers,
+                    jar,
+                    resolveWithFullResponse: true,
+                    timeout: 5000
+                });
+
+                // resultData.metadata.fileSize = response.headers['content-length'];
+                resultData.file.kind = response.headers['content-type'];
+                resultData.metadata.isDownload = response.headers['accept-ranges'] !== 'bytes';
+            } catch(err) {
+                logger.error(err);
+            }
+        }
+        return resultData;
+    }
+
+    async setFileInfo(resultData) {
+        if (resultData.event === 'result') {
+            const jar = this.rp.jar();
+            const headers = resultData.headers || {};
+
+            if (resultData.metadata.cookie) {
+                const splitCookie = resultData.metadata.cookie.split('=');
+                const cookie = new tough.Cookie({
+                    key: splitCookie[0],
+                    value: splitCookie[1]
+                });
+                jar.setCookie(cookie, resultData.file.data);
+            }
+
+            try {
+                const response = await ffprobe({
+                    uri: resultData.file.data,
+                    method: 'HEAD',
+                    headers,
+                    jar,
+                    resolveWithFullResponse: true,
+                    timeout: 5000
+                }, {path: ffprobeStatic.path});
+
+                // resultData.metadata.fileSize = response.headers['content-length'];
+                resultData.file.kind = response.headers['content-type'];
+                resultData.metadata.isDownload = response.headers['accept-ranges'] !== 'bytes';
+            } catch(err) {
+                logger.error(err);
+            }
+        }
+        return resultData;
+    }
+}
+
+
+module.exports = exports = WsWrapper;

--- a/src/utils/WsWrapper.js
+++ b/src/utils/WsWrapper.js
@@ -24,7 +24,8 @@ class WsWrapper {
     async send(resultData) {
         if (this.shouldSend(resultData)) {
             await this.setHeadInfo(resultData);
-            await this.setFileInfo(resultData);
+            // Commenting this out until we get a better workflow for retrieving file data consistently
+            // await this.setFileInfo(resultData);
             try {
                 this.ws.send(JSON.stringify(resultData));
                 this.sentLinks.push(resultData.file.data);

--- a/src/utils/createEvent.js
+++ b/src/utils/createEvent.js
@@ -16,7 +16,6 @@ function createEvent(data, ipLocked, pairing, {quality, provider, source, isResu
         event: 'result',
         file: {
             data,
-            kind: getDataKind(data),
         },
         isResultOfScrape,
         metadata: {
@@ -27,22 +26,6 @@ function createEvent(data, ipLocked, pairing, {quality, provider, source, isResu
         },
         headers
     };
-}
-
-function getDataKind(link) {
-    const file = URL.parse(link).pathname;
-
-    if (file.endsWith('.mp4')) {
-        return 'video/mp4';
-    } else if (file.endsWith('.m3u8')) {
-        return 'application/x-mpegURL';
-    } else if (file.endsWith('.mkv')) {
-        return 'video/x-matroska';
-    } else if (file.endsWith('==')) {
-        return 'file';
-    } else {
-        return 'video/*';
-    }
 }
 
 module.exports = exports = createEvent;

--- a/src/utils/createEvent.js
+++ b/src/utils/createEvent.js
@@ -1,6 +1,6 @@
 const URL = require('url');
 
-function createEvent(data, ipLocked, pairing, {quality, provider, source, isDownload = false, isResultOfScrape = false, cookieRequired = '', cookie = ''}, headers) {
+function createEvent(data, ipLocked, pairing, {quality, provider, source, isResultOfScrape = false, cookieRequired = '', cookie = ''}, headers) {
     if (ipLocked) {
         return {
             event: 'scrape',
@@ -23,7 +23,6 @@ function createEvent(data, ipLocked, pairing, {quality, provider, source, isDown
             quality,
             provider,
             source,
-            isDownload,
             cookie
         },
         headers

--- a/src/utils/createEvent.js
+++ b/src/utils/createEvent.js
@@ -6,8 +6,8 @@ function createEvent(data, ipLocked, pairing, {quality, provider, source, isResu
             event: 'scrape',
             target: pairing.target,
             headers,
-            source,
-            resolver: provider,
+            provider,
+            resolver: source,
             cookieRequired
         }
     }

--- a/src/utils/eventEmitter.js
+++ b/src/utils/eventEmitter.js
@@ -1,4 +1,0 @@
-const EventEmitter = require('events');
-const emitter = new EventEmitter();
-
-module.exports = exports = emitter;

--- a/src/utils/ffprobe.js
+++ b/src/utils/ffprobe.js
@@ -9,9 +9,9 @@ const { execFile } = require('child_process')
  * @param   {Array<String>} args Array of arguments passed to ffprobe
  * @returns {Promise<Object>}    Promise that resolves to the ffprobe JSON output
  */
-function ffprobeExecFile (path, args) {
+function ffprobeExecFile (path, args, options) {
   return new Promise((resolve, reject) => {
-    execFile(path, args, (err, stdout, stderr) => {
+    execFile(path, args, options, (err, stdout, stderr) => {
       if (err) {
         if (err.code === 'ENOENT') {
           reject(err)
@@ -44,7 +44,21 @@ function ffprobe (target, config = {}) {
     target
   ]
 
-  return ffprobeExecFile(path, args)
+  if (config.headers) {
+    args.push('-headers')
+    let headersArg = ''
+    for (let header in config.headers) {
+      headersArg += `${header}: ${config.headers[header]}\r\n`
+    }
+    args.push(headersArg)
+  }
+
+  if (config.endOffset) {
+    args.push('-end_offset')
+    args.push(config.endOffset)
+  }
+
+  return ffprobeExecFile(path, args, config.execOptions)
 }
 
 module.exports = ffprobe

--- a/src/utils/ffprobe.js
+++ b/src/utils/ffprobe.js
@@ -1,0 +1,50 @@
+'use strict'
+
+const { execFile } = require('child_process')
+
+/**
+ * Executes ffprobe with provided arguments
+ * @func    ffprobeExecFile
+ * @param   {String}        path Path of the ffprobe binary
+ * @param   {Array<String>} args Array of arguments passed to ffprobe
+ * @returns {Promise<Object>}    Promise that resolves to the ffprobe JSON output
+ */
+function ffprobeExecFile (path, args) {
+  return new Promise((resolve, reject) => {
+    execFile(path, args, (err, stdout, stderr) => {
+      if (err) {
+        if (err.code === 'ENOENT') {
+          reject(err)
+        } else {
+          const ffprobeErr = new Error(stderr.split('\n').pop())
+          reject(ffprobeErr)
+        }
+      } else {
+        resolve(JSON.parse(stdout))
+      }
+    })
+  })
+}
+
+/**
+ * Analyzes a video with ffprobe
+ * @func    ffprobe
+ * @param   {String} target   The file path or remote URL of the video
+ * @param   {Object} [config={}]             A configuration object
+ * @param   {String} [config.path='ffprobe'] Path of the ffprobe binary
+ * @returns {Promise<Object>} Promise that resolves to the ffprobe JSON output
+ */
+function ffprobe (target, config = {}) {
+  const path = config.path || process.env.FFPROBE_PATH || 'ffprobe'
+  const args = [
+    '-show_streams',
+    '-show_format',
+    '-print_format',
+    'json',
+    target
+  ]
+
+  return ffprobeExecFile(path, args)
+}
+
+module.exports = ffprobe

--- a/tests/resolvers/Mp4Upload.js
+++ b/tests/resolvers/Mp4Upload.js
@@ -37,13 +37,13 @@ describe('Mp4Upload', function () {
         expect(uriEmbedNormalized).to.be.equal(normalizedUrl);
     });
 
-    it('should resolve html links', function () {
+    it('should resolve html links', async function () {
         // 1. ARRANGE
         let html = readTestAsset('resolvers/mp4upload/5s2j789k6lg5.html');
         let meta = {};
 
         // 2. ACT
-        let results = instance.resolveHtml(meta, html, null, null);
+        let results = await instance.resolveHtml(meta, html, null, null);
 
         // 3. ASSERT
         expect(results.length).to.be.equal(1);

--- a/tests/resolvers/StreamLewd.js
+++ b/tests/resolvers/StreamLewd.js
@@ -5,13 +5,13 @@ const StreamLewd = require('../../src/scrapers/resolvers/StreamLewd');
 let instance = new StreamLewd();
 
 describe('StreamLewd', function () {
-    it('should resolve html links', function () {
+    it('should resolve html links', async function () {
         // 1. ARRANGE
         let html = readTestAsset('resolvers/stream-lewd/DaWDkPJQ3wry2mV.html');
         let meta = {};
 
         // 2. ACT
-        let results = instance.resolveHtml(meta, html, null, null);
+        let results = await instance.resolveHtml(meta, html, null, null);
 
         // 3. ASSERT
         expect(results.length).to.be.equal(4);

--- a/tests/resolvers/TikiWiki.js
+++ b/tests/resolvers/TikiWiki.js
@@ -5,13 +5,13 @@ const TikiWiki = require('../../src/scrapers/resolvers/TikiWiki');
 let instance = new TikiWiki();
 
 describe('TikiWiki', function () {
-    it('should resolve html links', function () {
+    it('should resolve html links', async function () {
         // 1. ARRANGE
         let html = readTestAsset('resolvers/tikiwiki/88yh05fbvjcx.html');
         let meta = {};
 
         // 2. ACT
-        let results = instance.resolveHtml(meta, html, null, null);
+        let results = await instance.resolveHtml(meta, html, null, null);
 
         // 3. ASSERT
         expect(results.length).to.be.equal(1);


### PR DESCRIPTION
Naming fixes:
sse => ws
isDownload => isStreamable
provider <=> source
Fixed GoWatchSeries class name
Added SeriesFree class name

Added:
ffprobe logic (commented out right now until we figure out consistency)
HEAD request info
WsWrapper: encapsulates filter logic and file/HEAD info

Removed:
`getDataKind` because we're getting `content-type` from the HEAD request