### PR TITLE
Dev ui : Add placeholder image when there's no poster.

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -186,6 +186,21 @@
                 display: flex;
                 align-items: flex-end;
                 cursor: pointer;
+                position: relative;
+            }
+
+            .search-result.no-image {
+                background-color: #696969; /* tee hee*/
+            }
+
+            .search-result.no-image:before {
+                content: "NO IMAGE";
+                position: absolute;
+                top: 77px;
+                font-weight: bold;
+                width: 100%;
+                text-align: center;
+                color: #c7c5c5;
             }
 
             .search-result > .search-result-title-container {
@@ -352,8 +367,12 @@
                 results = responseJSON.results;
                 for(let result of results) {
                     const resultContainer = document.createElement('div');
-                    resultContainer.style.background = `url('https://image.tmdb.org/t/p/w200${result.poster_path}') center / cover`;
                     resultContainer.classList.add('search-result');
+                    if (result.poster_path) {
+                        resultContainer.style.background = `url('https://image.tmdb.org/t/p/w200${result.poster_path}') center / cover`;
+                    } else {
+                        resultContainer.classList.add('no-image');
+                    }
                     const titleContainer = document.createElement('div');
                     titleContainer.classList.add('search-result-title-container');
                     const title = document.createElement('span');


### PR DESCRIPTION
- Add placeholder "image" when the tmdb doesn't have a poster, rather than 404ing.

![image](https://user-images.githubusercontent.com/45653919/54886509-84110880-4e80-11e9-8032-816c0066bed7.png)
