### PR TITLE
Use NTP Time (Auth)

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "rate-limiter-flexible": "^0.19.6",
     "request": "^2.88.0",
     "request-promise": "^4.2.2",
+    "sntp": "^3.0.2",
     "url": "^0.11.0",
     "winston": "^3.2.1",
     "ws": "^6.1.3"

--- a/src/api/authRoutes.js
+++ b/src/api/authRoutes.js
@@ -5,6 +5,7 @@ const Salsa20 = require('js-salsa20')
 const {TextEncoder, TextDecoder} = require('util');
 const jwt = require('jsonwebtoken');
 const {RateLimiterCluster, RateLimiterMemory} = require('rate-limiter-flexible');
+const sntp = require('sntp');
 
 // Define constants
 const authDelay = 10;
@@ -40,8 +41,10 @@ async function login(req, res) {
         const message = decoder.decode(messageBytes);
 
         let clientIsValid = false;
-        const now = Math.floor((new Date()).valueOf() / 1000);
-
+        await sntp.start();
+        const now = Math.floor(sntp.now() / 1000);
+        sntp.stop();
+        
         for (let time = now; time >= now - authDelay && !clientIsValid; time--) {
             clientIsValid = message === `${time}|${process.env.SECRET_CLIENT_ID}`
         }


### PR DESCRIPTION
Kamino uses NTP time now for authentication token. Thus, Claws needs to as well to compare and match the token appropriately. This should prevent a `401` on `/api/v1/login`.