### PR TITLE
fix(RapidVideo): get all available links from resolver

### DIFF
--- a/src/scrapers/resolvers/RapidVideo.js
+++ b/src/scrapers/resolvers/RapidVideo.js
@@ -4,15 +4,24 @@ const logger = require('../../utils/logger');
 
 async function RapidVideo(uri, jar) {
     try {
-        let providerPageHtml = await rp({
-            uri,
-            jar,
-            timeout: 5000
-        });
-    
+        let providerPageHtml = await rp({ uri, jar, timeout: 5000 });
         $ = cheerio.load(providerPageHtml);
-    
-        return $('source').attr('src');
+
+        let videoLinks = $('div a div').toArray().reduce((returnArray, element) => {
+            let qualitySpecificLink = $(element).parent().attr('href');
+            returnArray.push(qualitySpecificLink);
+            return returnArray;
+        }, []);
+
+        let resolvedLinks = [];
+        for (let videoLink of videoLinks) {
+            let videoPageHTML = await rp({ uri: videoLink, jar, timeout: 5000 });
+            $ = cheerio.load(videoPageHTML)
+            let resolvedLink = $('video source').attr('src');
+            resolvedLinks.push(resolvedLink);
+        }
+
+        return resolvedLinks;
     } catch (err) {
         logger.error(err)
     }

--- a/src/scrapers/resolvers/resolve.js
+++ b/src/scrapers/resolvers/resolve.js
@@ -96,10 +96,13 @@ async function resolve(ws, uri, provider, jar, headers, quality = '', meta = {})
             await ws.send(event, event.event);
 
         } else if (uri.includes('rapidvideo.com')) {
-            const data = await RapidVideo(uri, jar);
-            const event = createEvent(data, false, undefined, {quality, source: 'RapidVideo', provider});
-            await ws.send(event, event.event);
-
+            const dataList = await RapidVideo(uri, jar);
+            if (dataList) {
+                for (const data of dataList) {
+                    const event = createEvent(data, false, undefined, {quality, source: 'RapidVideo', provider});
+                    await ws.send(event, event.event);
+                }
+            }
         } else if (uri.includes('azmovies.co') || uri.includes('azmovies.ws')) {
             const file = await AZMovies(uri, jar, headers);
             const event = createEvent(file, false, undefined, {quality, source: 'AZMovies', provider});


### PR DESCRIPTION
## fix(RapidVideo): get all available links from resolver
Updated the RapidVideo resolver to actually retrieve the video source as well as getting different quality links.

### What's in this PR:
- Retrieve video source using the `video` tag and then `source`.
- Have the RapidVideo resolver return an array of links instead because the page may contain different qualities.
