### PR TITLE
fix(provider) remove 5Movies due to access ban

### DIFF
--- a/src/scrapers/providers/universal/SolarMovie.js
+++ b/src/scrapers/providers/universal/SolarMovie.js
@@ -7,7 +7,7 @@ module.exports = class SolarMovie extends BaseProvider {
     /** @inheritdoc */
     getUrls() {
         // Removing 5Movies (http://5movies.fm) because of access ban
-        return ['http://www1.solarmovie.net',];
+        return ['http://www1.solarmovie.net'];
     }
 
     /** @inheritdoc */

--- a/src/scrapers/providers/universal/SolarMovie.js
+++ b/src/scrapers/providers/universal/SolarMovie.js
@@ -6,7 +6,8 @@ const atob = require('atob');
 module.exports = class SolarMovie extends BaseProvider {
     /** @inheritdoc */
     getUrls() {
-        return ['http://www1.solarmovie.net', 'http://5movies.fm'];
+        // Removing 5Movies (http://5movies.fm) because of access ban
+        return ['http://www1.solarmovie.net',];
     }
 
     /** @inheritdoc */


### PR DESCRIPTION
As @kevincosmos found out, 5Movies essentially will ban access to them after time. Which means there is no point having 5Movies as an alternate URL in the SolarMovie provider. I left a comment just for reference in case there is some sort of bypass implemented in the future.