### PR TITLE
Add route to get NTP from Claws.

### DIFF
--- a/src/api/authRoutes.js
+++ b/src/api/authRoutes.js
@@ -95,4 +95,12 @@ if (process.env.RATE_LIMITER === 'true') {
     authRoutes.post('/login', login);
 }
 
+authRoutes.get('/ntp', (req, res) => {
+    await sntp.start();
+    const now = Math.floor(sntp.now() / 1000);
+    sntp.stop();
+    
+    res.send(now);
+});
+
 module.exports = authRoutes;


### PR DESCRIPTION
It seems Kamino has issues connecting to NTP servers on some cell phone providers.
Perhaps they (inadvertently) block them?

This endpoint gets around that.