### PR TITLE
fix(web-interface) use dynamic websocket host

### DIFF
--- a/public/ui/index.html
+++ b/public/ui/index.html
@@ -255,6 +255,8 @@
         const TMDB_API_KEY = '<%= tmdb_api_key %>';
         const SECRET_CLIENT_ID = '<%= secret_client_id %>';
 
+        const socketHost = location.origin.replace(/^http/, 'ws');
+
         let ws;
         let results = [];
         let scrapes = 0;
@@ -326,7 +328,7 @@
             stop(); // Stop existing websocket.
             const response = await fetch(`https://api.themoviedb.org/3/movie/${searchData.id}/external_ids?api_key=${TMDB_API_KEY}`);
             const responseJSON = await response.json();
-            ws = new WebSocket(`ws://localhost:3000/?token=${token}`);
+            ws = new WebSocket(`${socketHost}/?token=${token}`);
             ws.onopen = function () {
                 // Web Socket is connected, send data using send()
                 ws.send(JSON.stringify({ type: 'movies', title: searchData.title, year: (new Date(searchData.release_date)).getFullYear(), tmdbId: searchData.id, imdbId: responseJSON.imdb_id }));
@@ -390,7 +392,7 @@
             stop(); // Stop existing websocket.
             const response = await fetch(`https://api.themoviedb.org/3/tv/${searchData.id}/external_ids?api_key=${TMDB_API_KEY}`);
             const responseJSON = await response.json();
-            ws = new WebSocket(`ws://localhost:3000/?token=${token}`);
+            ws = new WebSocket(`${socketHost}/?token=${token}`);
             let isAnime = document.getElementById('isAnime').checked;
             ws.onopen = function () {
                 // Web Socket is connected, send data using send()


### PR DESCRIPTION
Essentially for the beta server, can't use the hard coded host as @j0j00 pointed out. Pulled out the relevant lines from his Heroku PR #55. This should allow access to the beta server's web interface now.