### PR TITLE
fix(WsWrapper) update setHeadInfo() to check for isResultOfScrape

### DIFF
--- a/src/utils/WsWrapper.js
+++ b/src/utils/WsWrapper.js
@@ -50,7 +50,7 @@ class WsWrapper {
     }
 
     async setHeadInfo(resultData) {
-        if (resultData.event === 'result') {
+        if (resultData.isResultOfScrape != true) {
             const jar = this.rp.jar();
             const headers = resultData.headers || {};
 


### PR DESCRIPTION
Due to the recent bug where we're losing `scrape` event data, the HEAD request for those events need to be done on the client side. Thus, from Claws this should ensure we skip trying to do head request if the result is from a `scrape` event by checking the `isResultOfScrape` boolean.