### PR TITLE
Update Quality Utility Function

### DIFF
--- a/src/scrapers/providers/movies/AZMovies.js
+++ b/src/scrapers/providers/movies/AZMovies.js
@@ -2,6 +2,7 @@ const cheerio = require('cheerio');
 const randomUseragent = require('random-useragent');
 const BaseProvider = require('../BaseProvider');
 const tough = require('tough-cookie');
+const Utils = require('../../../utils/index');
 
 module.exports = class AZMovies extends BaseProvider {
     /** @inheritdoc */
@@ -73,9 +74,11 @@ module.exports = class AZMovies extends BaseProvider {
 
             $ = cheerio.load(videoPageHtml);
 
+            let quality = Utils.getNumericQuality($('.quality').text());
+
             $('#serverul li a').toArray().forEach((element) => {
                 const providerUrl = this._absoluteUrl(movieUrl, $(element).attr('href'));
-                resolvePromises.push(this.resolveLink(providerUrl, ws, jar, headers, '', { isDDL: false}, hasRD));
+                resolvePromises.push(this.resolveLink(providerUrl, ws, jar, headers, quality, { isDDL: false}, hasRD));
             });
         }
         catch (err) {

--- a/src/scrapers/providers/movies/BFMovies.js
+++ b/src/scrapers/providers/movies/BFMovies.js
@@ -1,5 +1,6 @@
 const cheerio = require('cheerio');
 const BaseProvider = require('../BaseProvider');
+const Utils = require('../../../utils/index');
 
 module.exports = class BFMovies extends BaseProvider {
     /** @inheritdoc */
@@ -44,6 +45,8 @@ module.exports = class BFMovies extends BaseProvider {
 
             $ = cheerio.load(videoPageHTML);
 
+            let quality = Utils.getNumericQuality($('.quality span').text());
+
             let openloadPage = $("iframe").attr('src');
             if(!openloadPage.includes("openload")){
                 this.logger.debug("BFMovies does not always use OpenLoad.");
@@ -53,7 +56,7 @@ module.exports = class BFMovies extends BaseProvider {
 
             let openloadURL = cheerio.load(openloadHTML)('meta[name="og:url"]').attr('content');
             if (openloadURL) {
-                resolvePromises.push(this.resolveLink(openloadURL, ws, jar, headers, '', { isDDL: false}, hasRD));
+                resolvePromises.push(this.resolveLink(openloadURL, ws, jar, headers, quality, { isDDL: false}, hasRD));
             } else {
                 return Promise.resolve();
             }

--- a/src/scrapers/resolvers/RapidVideo.js
+++ b/src/scrapers/resolvers/RapidVideo.js
@@ -1,6 +1,7 @@
 const rp = require('request-promise');
 const cheerio = require('cheerio');
 const logger = require('../../utils/logger');
+const Utils = require('../../utils/index');
 
 async function RapidVideo(uri, jar) {
     try {
@@ -16,7 +17,7 @@ async function RapidVideo(uri, jar) {
         let resolvedData = [];
         for (let videoLink of videoLinks) {
             let splitComponents = videoLink.split('q=');
-            let quality = splitComponents[splitComponents.length - 1];
+            let quality = Utils.getNumericQuality(splitComponents[splitComponents.length - 1]);
 
             let videoPageHTML = await rp({ uri: videoLink, jar, timeout: 5000 });
             $ = cheerio.load(videoPageHTML)

--- a/src/scrapers/resolvers/XStreamCDN.js
+++ b/src/scrapers/resolvers/XStreamCDN.js
@@ -1,7 +1,5 @@
 const BaseResolver = require('./_BaseResolver');
-
-const cheerio = require('cheerio');
-const vm = require('vm');
+const Utils = require('../../utils/index');
 
 const urlRegex = /(https?:\/\/(?:www.)?xstreamcdn.com)\/v\/([0-9a-zA-Z]+?)(\.html)?$/;
 
@@ -50,7 +48,7 @@ module.exports = class XStreamCDN extends BaseResolver {
                 links.push({
                     data: link.file,
                     meta: {
-                        quality: link.label, // e.g. 480p
+                        quality: Utils.getNumericQuality(link.label), // e.g. 480p
                         type: link.type, // e.g. mp4
                     }
                 })

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -125,7 +125,7 @@ module.exports = {
     getQualityInfo: (filename) => {
         filename = decodeURI(filename.toLowerCase());
 
-        if (/([^a-zA-Z0-9])(2160p?)([^a-zA-Z0-9])/g.test(filename)) {
+        if (/([^a-zA-Z0-9])(2160p?|4k)([^a-zA-Z0-9])/g.test(filename)) {
             return 2160;
         } else if (/([^a-zA-Z0-9])(1080p?)([^a-zA-Z0-9])/g.test(filename)) {
             return 1080;
@@ -133,11 +133,33 @@ module.exports = {
             return 720;
         } else if (/([^a-zA-Z0-9])(480p?)([^a-zA-Z0-9])/g.test(filename)) {
             return 480;
-        } else if (/([^a-zA-Z0-9])(dvdscr|r5|r6)([^a-zA-Z0-9])/g.test(filename)) {
+        } else if (/([^a-zA-Z0-9])(scr|dvdscr|r5|r6)([^a-zA-Z0-9])/g.test(filename)) {
             return 450;
         } else if (/([^a-zA-Z0-9])(360p?)([^a-zA-Z0-9])/g.test(filename)) {
             return 360;
-        } else if (/([^a-zA-Z0-9])(camrip|tsrip|hdcam|hdts|dvdcam|dvdts|cam|telesync|ts)([^a-zA-Z0-9])/g.test(filename)) {
+        } else if (/([^a-zA-Z0-9])(cam|camrip|tsrip|hdcam|hdts|dvdcam|dvdts|cam|telesync|ts)([^a-zA-Z0-9])/g.test(filename)) {
+            return 300;
+        } else {
+            return 0;
+        }
+    },
+
+    getNumericQuality: (quality) => {
+        quality = quality.toLowerCase();
+
+        if (/(2160p?|4k)/g.test(quality)) {
+            return 2160;
+        } else if (/(1080p?)/g.test(quality)) {
+            return 1080;
+        } else if (/(720p?|brrip|hd)/g.test(quality)) {
+            return 720;
+        } else if (/(480p?)/g.test(quality)) {
+            return 480;
+        } else if (/(scr|dvdscr|r5|r6)/g.test(quality)) {
+            return 450;
+        } else if (/(360p?)/g.test(quality)) {
+            return 360;
+        } else if (/(cam|camrip|tsrip|hdcam|hdts|dvdcam|dvdts|cam|telesync|ts)/g.test(quality)) {
             return 300;
         } else {
             return 0;

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -125,19 +125,19 @@ module.exports = {
     getQualityInfo: (filename) => {
         filename = decodeURI(filename.toLowerCase());
 
-        if (/([^a-zA-Z0-9])(2160p?|4k|uhd)([^a-zA-Z0-9])/g.test(filename)) {
+        if (/([^a-z0-9])(2160p?|4k|uhd)([^a-z0-9])/g.test(filename)) {
             return 2160;
-        } else if (/([^a-zA-Z0-9])(1080p?)([^a-zA-Z0-9])/g.test(filename)) {
+        } else if (/([^a-z0-9])(1080p?)([^a-z0-9])/g.test(filename)) {
             return 1080;
-        } else if (/([^a-zA-Z0-9])(720p?|brrip|hd)([^a-zA-Z0-9])/g.test(filename)) {
+        } else if (/([^a-z0-9])(720p?|brrip|hd)([^a-z0-9])/g.test(filename)) {
             return 720;
-        } else if (/([^a-zA-Z0-9])(480p?)([^a-zA-Z0-9])/g.test(filename)) {
+        } else if (/([^a-z0-9])(480p?)([^a-z0-9])/g.test(filename)) {
             return 480;
-        } else if (/([^a-zA-Z0-9])(scr|dvdscr|r5|r6)([^a-zA-Z0-9])/g.test(filename)) {
+        } else if (/([^a-z0-9])(scr|dvdscr|r5|r6)([^a-z0-9])/g.test(filename)) {
             return 450;
-        } else if (/([^a-zA-Z0-9])(360p?)([^a-zA-Z0-9])/g.test(filename)) {
+        } else if (/([^a-z0-9])(360p?)([^a-z0-9])/g.test(filename)) {
             return 360;
-        } else if (/([^a-zA-Z0-9])(cam|camrip|tsrip|hdcam|hdts|dvdcam|dvdts|cam|telesync|ts)([^a-zA-Z0-9])/g.test(filename)) {
+        } else if (/([^a-z0-9])(cam|camrip|tsrip|hdcam|hdts|dvdcam|dvdts|cam|telesync|ts)([^a-z0-9])/g.test(filename)) {
             return 300;
         } else {
             return 0;

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -121,27 +121,24 @@ module.exports = {
      * @param filename The name of the file.
      */
     getQualityInfo: (filename) => {
-        filename = filename.toLowerCase();
-        if (filename.includes('2160')) {
-            return '4K';
-        } else if (filename.includes('1080')) {
-            return '1080p';
-        } else if (filename.includes('720')) {
-            return '720p';
-        } else if (filename.includes('480')) {
-            return '480p';
-        } else if (filename.includes('360')) {
-            return '360p';
-        } else if (filename.includes('brrip')) {
-            return '720p';
-        } else if (filename.includes('.hd.')) {
-            return '720p';
-        } else if (['dvdscr', 'r5', 'r6'].some(element => filename.includes(element))) {
-            return 'SCR';
-        } else if (['camrip', 'tsrip', 'hdcam', 'hdts', 'dvdcam', 'dvdts', 'cam', 'telesync', 'ts'].some(element => filename.includes(element))) {
-            return 'CAM';
+        filename = decodeURI(filename.toLowerCase());
+
+        if (/([^a-zA-Z0-9])(2160p?)([^a-zA-Z0-9])/g.test(filename)) {
+            return 2160;
+        } else if (/([^a-zA-Z0-9])(1080p?)([^a-zA-Z0-9])/g.test(filename)) {
+            return 1080;
+        } else if (/([^a-zA-Z0-9])(720p?|brrip|\.hd\.)([^a-zA-Z0-9])/g.test(filename)) {
+            return 720;
+        } else if (/([^a-zA-Z0-9])(480p?)([^a-zA-Z0-9])/g.test(filename)) {
+            return 480;
+        } else if (/([^a-zA-Z0-9])(dvdscr|r5|r6)([^a-zA-Z0-9])/g.test(filename)) {
+            return 450;
+        } else if (/([^a-zA-Z0-9])(360p?)([^a-zA-Z0-9])/g.test(filename)) {
+            return 360;
+        } else if (/([^a-zA-Z0-9])(camrip|tsrip|hdcam|hdts|dvdcam|dvdts|cam|telesync|ts)([^a-zA-Z0-9])/g.test(filename)) {
+            return 300;
         } else {
-            return 'HQ';
+            return 0;
         }
     }
 };

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -125,7 +125,7 @@ module.exports = {
     getQualityInfo: (filename) => {
         filename = decodeURI(filename.toLowerCase());
 
-        if (/([^a-zA-Z0-9])(2160p?|4k)([^a-zA-Z0-9])/g.test(filename)) {
+        if (/([^a-zA-Z0-9])(2160p?|4k|uhd)([^a-zA-Z0-9])/g.test(filename)) {
             return 2160;
         } else if (/([^a-zA-Z0-9])(1080p?)([^a-zA-Z0-9])/g.test(filename)) {
             return 1080;
@@ -147,7 +147,7 @@ module.exports = {
     getNumericQuality: (quality) => {
         quality = quality.toLowerCase();
 
-        if (/(2160p?|4k)/g.test(quality)) {
+        if (/(2160p?|4k|uhd)/g.test(quality)) {
             return 2160;
         } else if (/(1080p?)/g.test(quality)) {
             return 1080;

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -129,7 +129,7 @@ module.exports = {
             return 2160;
         } else if (/([^a-zA-Z0-9])(1080p?)([^a-zA-Z0-9])/g.test(filename)) {
             return 1080;
-        } else if (/([^a-zA-Z0-9])(720p?|brrip|\.hd\.)([^a-zA-Z0-9])/g.test(filename)) {
+        } else if (/([^a-zA-Z0-9])(720p?|brrip|hd)([^a-zA-Z0-9])/g.test(filename)) {
             return 720;
         } else if (/([^a-zA-Z0-9])(480p?)([^a-zA-Z0-9])/g.test(filename)) {
             return 480;


### PR DESCRIPTION
### Main Changes
- Updated the quality utility function to return integer values as noted in #121 
- Now uses regex to check for the quality instead of string comparisons

### Other Changes
- Added a method called `getNumericValue`to convert quality as a string to it's representative numeric value
- Updated RapidVideo to use `getNumericValue`
- Updated XStreamCDN to use `getNumericValue`
- AZMovies provider retrieves quality from the video page

### Notes
This should not be pushed to the server until Kamino implements the conversion from integers to strings for quality, as it seems to drop sources if quality is an integer...