### PR TITLE
DDLSpot Handle Colons

### DIFF
--- a/src/scrapers/providers/rd/universal/DDLSpot.js
+++ b/src/scrapers/providers/rd/universal/DDLSpot.js
@@ -20,7 +20,7 @@ module.exports = class DDLSpot extends BaseProvider {
         let headers = {};
 
         try {
-            let searchTitle = `${title}`;
+            let searchTitle = title.replace(':', '');
             const paddedSeason = `${season}`.padStart(2, '0');
             const paddedEpisode = `${episode}`.padStart(2, '0');
             const formattedEpisode = `s${paddedSeason}e${paddedEpisode}`;


### PR DESCRIPTION
So search was failing with any title with a colon in it because the results don't contain them. This just gets rid of any colons during search. The example I was looking at was `Avengers: Infinity War`. With this changes, it now works successfully!